### PR TITLE
Link video files to YouTube playlist

### DIFF
--- a/course-zoomcamp/01-intro/01-what-is-ml.md
+++ b/course-zoomcamp/01-intro/01-what-is-ml.md
@@ -1,6 +1,6 @@
 ## 1.1 Introduction to Machine Learning
 
-<a href="https://www.youtube.com/watch?v=Crm_5n4mvmg"><img src="images/thumbnail-1-01.jpg"></a>
+<a href="https://www.youtube.com/watch?v=Crm_5n4mvmg&list=PL3MmuxUbc_hIhxl5Ji8t4O6lPAOpHaCLR&index=2"><img src="images/thumbnail-1-01.jpg"></a>
 
 [Slides](https://www.slideshare.net/AlexeyGrigorev/ml-zoomcamp-11-introduction-to-machine-learning)
 

--- a/course-zoomcamp/01-intro/02-ml-vs-rules.md
+++ b/course-zoomcamp/01-intro/02-ml-vs-rules.md
@@ -1,6 +1,6 @@
 ## 1.2 ML vs Rule-Based Systems
 
-<a href="https://www.youtube.com/watch?v=CeukwyUdaz8"><img src="images/thumbnail-1-02.jpg"></a>
+<a href="https://www.youtube.com/watch?v=CeukwyUdaz8&list=PL3MmuxUbc_hIhxl5Ji8t4O6lPAOpHaCLR&index=3"><img src="images/thumbnail-1-02.jpg"></a>
 
 [Slides](https://www.slideshare.net/AlexeyGrigorev/ml-zoomcamp-12-ml-vs-rulebased-systems)
 

--- a/course-zoomcamp/01-intro/03-supervised-ml.md
+++ b/course-zoomcamp/01-intro/03-supervised-ml.md
@@ -1,6 +1,6 @@
 ## 1.3 Supervised Machine Learning
 
-<a href="https://www.youtube.com/watch?v=j9kcEuGcC2Y"><img src="images/thumbnail-1-03.jpg"></a>
+<a href="https://www.youtube.com/watch?v=j9kcEuGcC2Y&list=PL3MmuxUbc_hIhxl5Ji8t4O6lPAOpHaCLR&index=4"><img src="images/thumbnail-1-03.jpg"></a>
 
 [Slides](https://www.slideshare.net/AlexeyGrigorev/ml-zoomcamp-13-supervised-machine-learning)
 

--- a/course-zoomcamp/01-intro/04-crisp-dm.md
+++ b/course-zoomcamp/01-intro/04-crisp-dm.md
@@ -1,6 +1,6 @@
 ## 1.4 CRISP-DM
 
-<a href="https://www.youtube.com/watch?v=dCa3JvmJbr0"><img src="images/thumbnail-1-04.jpg"></a>
+<a href="https://www.youtube.com/watch?v=dCa3JvmJbr0&list=PL3MmuxUbc_hIhxl5Ji8t4O6lPAOpHaCLR&index=5"><img src="images/thumbnail-1-04.jpg"></a>
 
 [Slides](https://www.slideshare.net/AlexeyGrigorev/ml-zoomcamp-14-crispdm)
 

--- a/course-zoomcamp/01-intro/05-model-selection.md
+++ b/course-zoomcamp/01-intro/05-model-selection.md
@@ -1,6 +1,6 @@
 ## 1.5 Model Selection Process
 
-<a href="https://www.youtube.com/watch?v=OH_R0Sl9neM"><img src="images/thumbnail-1-05.jpg"></a>
+<a href="https://www.youtube.com/watch?v=OH_R0Sl9neM&list=PL3MmuxUbc_hIhxl5Ji8t4O6lPAOpHaCLR&index=6"><img src="images/thumbnail-1-05.jpg"></a>
 
 [Slides](https://www.slideshare.net/AlexeyGrigorev/ml-zoomcamp-15-model-selection-process)
 

--- a/course-zoomcamp/01-intro/07-numpy.md
+++ b/course-zoomcamp/01-intro/07-numpy.md
@@ -1,6 +1,6 @@
 ## 1.7 Introduction to NumPy
 
-<a href="https://www.youtube.com/watch?v=Qa0-jYtRdbY"><img src="images/thumbnail-1-07.jpg"></a>
+<a href="https://www.youtube.com/watch?v=Qa0-jYtRdbY&list=PL3MmuxUbc_hIhxl5Ji8t4O6lPAOpHaCLR&index=7"><img src="images/thumbnail-1-07.jpg"></a>
 
 
 ## Notes

--- a/course-zoomcamp/01-intro/08-linear-algebra.md
+++ b/course-zoomcamp/01-intro/08-linear-algebra.md
@@ -1,6 +1,6 @@
 ## 1.8 Linear Algebra Refresher
 
-<a href="https://www.youtube.com/watch?v=zZyKUeOR4Gg"><img src="images/thumbnail-1-08.jpg"></a>
+<a href="https://www.youtube.com/watch?v=zZyKUeOR4Gg&list=PL3MmuxUbc_hIhxl5Ji8t4O6lPAOpHaCLR&index=8"><img src="images/thumbnail-1-08.jpg"></a>
 
 [Slides](https://www.slideshare.net/AlexeyGrigorev/ml-zoomcamp-18-linear-algebra-refresher)
 

--- a/course-zoomcamp/01-intro/09-pandas.md
+++ b/course-zoomcamp/01-intro/09-pandas.md
@@ -1,6 +1,6 @@
 ## 1.9 Introduction to Pandas
 
-<a href="https://www.youtube.com/watch?v=0j3XK5PsnxA"><img src="images/thumbnail-1-09.jpg"></a>
+<a href="https://www.youtube.com/watch?v=0j3XK5PsnxA&list=PL3MmuxUbc_hIhxl5Ji8t4O6lPAOpHaCLR&index=9"><img src="images/thumbnail-1-09.jpg"></a>
 
 
 ## Notes

--- a/course-zoomcamp/01-intro/10-summary.md
+++ b/course-zoomcamp/01-intro/10-summary.md
@@ -1,6 +1,6 @@
 ## 1.10 Summary
 
-<a href="https://www.youtube.com/watch?v=VRrEEVeJ440"><img src="images/thumbnail-1-10.jpg"></a>
+<a href="https://www.youtube.com/watch?v=VRrEEVeJ440&list=PL3MmuxUbc_hIhxl5Ji8t4O6lPAOpHaCLR&index=10"><img src="images/thumbnail-1-10.jpg"></a>
 
 [Slides](https://www.slideshare.net/AlexeyGrigorev/ml-zoomcamp-110-summary)
 

--- a/course-zoomcamp/02-regression/01-car-price-intro.md
+++ b/course-zoomcamp/02-regression/01-car-price-intro.md
@@ -1,7 +1,7 @@
 
 ## 2.1 Car price prediction project
 
-<a href="https://www.youtube.com/watch?v=vM3SqPNlStE"><img src="images/thumbnail-2-01.jpg"></a>
+<a href="https://www.youtube.com/watch?v=vM3SqPNlStE&list=PL3MmuxUbc_hIhxl5Ji8t4O6lPAOpHaCLR&index=12"><img src="images/thumbnail-2-01.jpg"></a>
 
 [Slides](https://www.slideshare.net/AlexeyGrigorev/ml-zoomcamp-21-car-price-prediction-project)
 

--- a/course-zoomcamp/02-regression/02-data-preparation.md
+++ b/course-zoomcamp/02-regression/02-data-preparation.md
@@ -1,7 +1,7 @@
 
 ## 2.2 Data preparation
 
-<a href="https://www.youtube.com/watch?v=Kd74oR4QWGM"><img src="images/thumbnail-2-02.jpg"></a>
+<a href="https://www.youtube.com/watch?v=Kd74oR4QWGM&list=PL3MmuxUbc_hIhxl5Ji8t4O6lPAOpHaCLR&index=13"><img src="images/thumbnail-2-02.jpg"></a>
 
 [Slides](https://www.slideshare.net/AlexeyGrigorev/ml-zoomcamp-2-slides)
 

--- a/course-zoomcamp/02-regression/03-eda.md
+++ b/course-zoomcamp/02-regression/03-eda.md
@@ -1,7 +1,7 @@
 
 ## 2.3 Exploratory data analysis
 
-<a href="https://www.youtube.com/watch?v=k6k8sQ0GhPM"><img src="images/thumbnail-2-03.jpg"></a>
+<a href="https://www.youtube.com/watch?v=k6k8sQ0GhPM&list=PL3MmuxUbc_hIhxl5Ji8t4O6lPAOpHaCLR&index=14"><img src="images/thumbnail-2-03.jpg"></a>
 
 [Slides](https://www.slideshare.net/AlexeyGrigorev/ml-zoomcamp-2-slides)
 

--- a/course-zoomcamp/02-regression/04-validation-framework.md
+++ b/course-zoomcamp/02-regression/04-validation-framework.md
@@ -1,7 +1,7 @@
 
 ## 2.4 Setting up the validation framework
 
-<a href="https://www.youtube.com/watch?v=ck0IfiPaQi0"><img src="images/thumbnail-2-04.jpg"></a>
+<a href="https://www.youtube.com/watch?v=ck0IfiPaQi0&list=PL3MmuxUbc_hIhxl5Ji8t4O6lPAOpHaCLR&index=15"><img src="images/thumbnail-2-04.jpg"></a>
 
 [Slides](https://www.slideshare.net/AlexeyGrigorev/ml-zoomcamp-2-slides)
 

--- a/course-zoomcamp/02-regression/05-linear-regression-simple.md
+++ b/course-zoomcamp/02-regression/05-linear-regression-simple.md
@@ -1,7 +1,7 @@
 
 ## 2.5 Linear regression
 
-<a href="https://www.youtube.com/watch?v=Dn1eTQLsOdA"><img src="images/thumbnail-2-05.jpg"></a>
+<a href="https://www.youtube.com/watch?v=Dn1eTQLsOdA&list=PL3MmuxUbc_hIhxl5Ji8t4O6lPAOpHaCLR&index=16"><img src="images/thumbnail-2-05.jpg"></a>
 
 [Slides](https://www.slideshare.net/AlexeyGrigorev/ml-zoomcamp-2-slides)
 

--- a/course-zoomcamp/02-regression/06-linear-regression-vector.md
+++ b/course-zoomcamp/02-regression/06-linear-regression-vector.md
@@ -1,7 +1,7 @@
 
 ## 2.6 Linear regression: vector form
 
-<a href="https://www.youtube.com/watch?v=YkyevnYyAww"><img src="images/thumbnail-2-06.jpg"></a>
+<a href="https://www.youtube.com/watch?v=YkyevnYyAww&list=PL3MmuxUbc_hIhxl5Ji8t4O6lPAOpHaCLR&index=17"><img src="images/thumbnail-2-06.jpg"></a>
 
 [Slides](https://www.slideshare.net/AlexeyGrigorev/ml-zoomcamp-2-slides)
 

--- a/course-zoomcamp/02-regression/07-linear-regression-training.md
+++ b/course-zoomcamp/02-regression/07-linear-regression-training.md
@@ -1,7 +1,7 @@
 
 ## 2.7 Training linear regression: Normal equation
 
-<a href="https://www.youtube.com/watch?v=hx6nak-Y11g"><img src="images/thumbnail-2-07.jpg"></a>
+<a href="https://www.youtube.com/watch?v=hx6nak-Y11g&list=PL3MmuxUbc_hIhxl5Ji8t4O6lPAOpHaCLR&index=18"><img src="images/thumbnail-2-07.jpg"></a>
 
 [Slides](https://www.slideshare.net/AlexeyGrigorev/ml-zoomcamp-2-slides)
 

--- a/course-zoomcamp/02-regression/08-baseline-model.md
+++ b/course-zoomcamp/02-regression/08-baseline-model.md
@@ -1,7 +1,7 @@
 
 ## 2.8 Baseline model for car price prediction project
 
-<a href="https://www.youtube.com/watch?v=SvPpMMYtYbU"><img src="images/thumbnail-2-08.jpg"></a>
+<a href="https://www.youtube.com/watch?v=SvPpMMYtYbU&list=PL3MmuxUbc_hIhxl5Ji8t4O6lPAOpHaCLR&index=19"><img src="images/thumbnail-2-08.jpg"></a>
 
 [Slides](https://www.slideshare.net/AlexeyGrigorev/ml-zoomcamp-2-slides)
 

--- a/course-zoomcamp/02-regression/09-rmse.md
+++ b/course-zoomcamp/02-regression/09-rmse.md
@@ -1,7 +1,7 @@
 
 ## 2.9 Root mean squared error
 
-<a href="https://www.youtube.com/watch?v=0LWoFtbzNUM"><img src="images/thumbnail-2-09.jpg"></a>
+<a href="https://www.youtube.com/watch?v=0LWoFtbzNUM&list=PL3MmuxUbc_hIhxl5Ji8t4O6lPAOpHaCLR&index=20"><img src="images/thumbnail-2-09.jpg"></a>
 
 [Slides](https://www.slideshare.net/AlexeyGrigorev/ml-zoomcamp-2-slides)
 

--- a/course-zoomcamp/02-regression/10-car-price-validation.md
+++ b/course-zoomcamp/02-regression/10-car-price-validation.md
@@ -1,7 +1,7 @@
 
 ## 2.10 Computing RMSE on validation data
 
-<a href="https://www.youtube.com/watch?v=rawGPXg2ofE"><img src="images/thumbnail-2-10.jpg"></a>
+<a href="https://www.youtube.com/watch?v=rawGPXg2ofE&list=PL3MmuxUbc_hIhxl5Ji8t4O6lPAOpHaCLR&index=21"><img src="images/thumbnail-2-10.jpg"></a>
 
 [Slides](https://www.slideshare.net/AlexeyGrigorev/ml-zoomcamp-2-slides)
 

--- a/course-zoomcamp/02-regression/11-feature-engineering.md
+++ b/course-zoomcamp/02-regression/11-feature-engineering.md
@@ -2,7 +2,7 @@
 
 Feature engineering is the process of creating new features
 
-<a href="https://www.youtube.com/watch?v=-aEShw4ftB0"><img src="images/thumbnail-2-11.jpg"></a>
+<a href="https://www.youtube.com/watch?v=-aEShw4ftB0&list=PL3MmuxUbc_hIhxl5Ji8t4O6lPAOpHaCLR&index=22"><img src="images/thumbnail-2-11.jpg"></a>
 
 [Slides](https://www.slideshare.net/AlexeyGrigorev/ml-zoomcamp-2-slides)
 

--- a/course-zoomcamp/02-regression/12-categorical-variables.md
+++ b/course-zoomcamp/02-regression/12-categorical-variables.md
@@ -1,7 +1,7 @@
 
 ## 2.12 Categorical variables
 
-<a href="https://www.youtube.com/watch?v=sGLAToAAMa4"><img src="images/thumbnail-2-12.jpg"></a>
+<a href="https://www.youtube.com/watch?v=sGLAToAAMa4&list=PL3MmuxUbc_hIhxl5Ji8t4O6lPAOpHaCLR&index=23"><img src="images/thumbnail-2-12.jpg"></a>
 
 [Slides](https://www.slideshare.net/AlexeyGrigorev/ml-zoomcamp-2-slides)
 

--- a/course-zoomcamp/02-regression/13-regularization.md
+++ b/course-zoomcamp/02-regression/13-regularization.md
@@ -1,6 +1,6 @@
 ## 2.13 Regularization
 
-<a href="https://www.youtube.com/watch?v=91ve3EJlHBc"><img src="images/thumbnail-2-13.jpg"></a>
+<a href="https://www.youtube.com/watch?v=91ve3EJlHBc&list=PL3MmuxUbc_hIhxl5Ji8t4O6lPAOpHaCLR&index=24"><img src="images/thumbnail-2-13.jpg"></a>
 
 [Slides](https://www.slideshare.net/AlexeyGrigorev/ml-zoomcamp-2-slides)
 

--- a/course-zoomcamp/02-regression/14-tuning-model.md
+++ b/course-zoomcamp/02-regression/14-tuning-model.md
@@ -1,7 +1,7 @@
 
 ## 2.14 Tuning the model
 
-<a href="https://www.youtube.com/watch?v=lW-YVxPgzQw"><img src="images/thumbnail-2-14.jpg"></a>
+<a href="https://www.youtube.com/watch?v=lW-YVxPgzQw&list=PL3MmuxUbc_hIhxl5Ji8t4O6lPAOpHaCLR&index=25"><img src="images/thumbnail-2-14.jpg"></a>
 
 [Slides](https://www.slideshare.net/AlexeyGrigorev/ml-zoomcamp-2-slides)
 

--- a/course-zoomcamp/02-regression/15-using-model.md
+++ b/course-zoomcamp/02-regression/15-using-model.md
@@ -1,7 +1,7 @@
 
 ## 2.15 Using the model
 
-<a href="https://www.youtube.com/watch?v=KT--uIJozes"><img src="images/thumbnail-2-15.jpg"></a>
+<a href="https://www.youtube.com/watch?v=KT--uIJozes&list=PL3MmuxUbc_hIhxl5Ji8t4O6lPAOpHaCLR&index=26"><img src="images/thumbnail-2-15.jpg"></a>
 
 [Slides](https://www.slideshare.net/AlexeyGrigorev/ml-zoomcamp-2-slides)
 

--- a/course-zoomcamp/02-regression/16-summary.md
+++ b/course-zoomcamp/02-regression/16-summary.md
@@ -1,7 +1,7 @@
 
 ## 2.16 Car price prediction project summary
 
-<a href="https://www.youtube.com/watch?v=_qI01YXbyro"><img src="images/thumbnail-2-16.jpg"></a>
+<a href="https://www.youtube.com/watch?v=_qI01YXbyro&list=PL3MmuxUbc_hIhxl5Ji8t4O6lPAOpHaCLR&index=27"><img src="images/thumbnail-2-16.jpg"></a>
 
 
 


### PR DESCRIPTION
@alexeygrigorev 

When I start a new week's video lectures, I first go to your GitHub and then click on the link to the YouTube videos. However, since the links don't contain the `list` URL param, the next video in the chapter won't automatically play next, and I find myself going to DataTalks.Club YT page > Playlists > clicking the playlist > finding my spot again, etc.

Anyways, I thought it would helpful to some to use specify the playlist in the video URLs so that the next lesson starts immediately after. I started doing the first two chapters before I figured I should get some feedback to see if this is something you're interested in.

Thanks!