### PR TITLE
Update slides link

### DIFF
--- a/course-zoomcamp/08-deep-learning/03-pretrained-models.md
+++ b/course-zoomcamp/08-deep-learning/03-pretrained-models.md
@@ -4,7 +4,7 @@
 <a href="https://www.youtube.com/watch?v=qGDXEz-cr6M"><img src="images/thumbnail-8-03.jpg"></a>
  
 
-[Slides](https://www.slideshare.net/AlexeyGrigorev/ml-zoomcamp-8-neural-networks-and-deep-learning-250592318)
+[Slides](https://www.slideshare.net/AlexeyGrigorev/ml-zoomcamp-8-neural-networks-and-deep-learning-250592316)
 
 
 ## Notes


### PR DESCRIPTION
for some reason only one link is correct (the one in the first video 8.1)
every other link is modified by adding 1 to the ones of the number in the link.