### PR TITLE
Updated Instructions (13 July, 2022)

### DIFF
--- a/course-zoomcamp/11-kserve/02-kserve-local.md
+++ b/course-zoomcamp/11-kserve/02-kserve-local.md
@@ -22,6 +22,15 @@ Add notes from the video (PRs are welcome)
    </tr>
 </table>
 
+### Updated Instructions (09 July, 2022)
+
+In the `iris-example.yaml` file, instead of `"gs://kfserving-samples/models/sklearn/iris"`, use `"gs://kfserving-examples/models/sklearn/1.0/model"` as the URL in storageUri.  
+
+Also make sure to use the following versions  
+- kind: 0.11.1 (via https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64)   
+- kubectl: 1.21.1 (via https://dl.k8s.io/release/v1.21.1/bin/linux/amd64/kubectl)    
+- kindest/node image: 1.21.1 (via `kind create cluster  --image kindest/node:v1.21.1`)       
+- kserve=0.8 (via https://raw.githubusercontent.com/kserve/kserve/release-0.8/hack/quick_install.sh)     
 
 ## Nagivation
 

--- a/course-zoomcamp/11-kserve/07-kserve-eks-upd.md
+++ b/course-zoomcamp/11-kserve/07-kserve-eks-upd.md
@@ -1,0 +1,69 @@
+## Deploying with KServe and EKS - Update (09 July, 2022)
+
+(These instructions assume that the user does not own a custom domain.)  
+
+- Download v1.21 of AWS' kubectl tool via  
+ `https://s3.us-west-2.amazonaws.com/amazon-eks/1.21.2/2021-07-05/bin/linux/amd64/kubectl`
+ 
+- Create a cluster (via `eksctl create cluster -f cluster.yaml`) using the following yaml file; note that we specify version 1.21 of k8s
+ 
+ ```
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: mlzoomcamp-eks
+  region: us-east-2
+  version: "1.21"
+
+nodeGroups:
+  - name: ng
+    desiredCapacity: 2
+    instanceType: m5.xlarge
+```
+
+- After downloading kserve==0.8 (via `wget https://raw.githubusercontent.com/kserve/kserve/release-0.8/hack/quick_install.sh`), set the version of Istio to 1.6.2 in line 33  
+- Then run `bash quick_install.sh`
+
+- Get the external IP from the ELB via  
+`kubectl get services -n istio-system`
+
+- Configure the secret key  
+`kubectl apply -f kserve-s3-secret.yaml`  
+
+- Create the Inference service  
+`kubectl apply -f clothes-service.yaml`
+
+- Create the file `test_transformer.py` with the following contents. Replace `actual_domain` with the external IP obtained from the ELB
+
+```python
+import requests
+
+
+service_name = 'clothes'
+host = f'{service_name}.default.example.com'
+
+actual_domain = 'http://{something here}.us-east-2.elb.amazonaws.com'
+service_url = f'{actual_domain}/v1/models/{service_name}:predict'
+
+headers = {'Host': host}
+
+
+request = {
+    "instances": [
+        {'url': 'http://bit.ly/mlbookcamp-pants'},
+        {'url': 'http://bit.ly/mlbookcamp-pants'}
+    ]
+}
+
+
+response = requests.post(service_url, json=request, headers=headers)
+
+print(response)
+print(response.content)
+print(response.json())
+```
+
+- Run `python test-transformer3.py` 
+
+- Delete cluster via `eksctl delete cluster --name mlzoomcamp-eks`

--- a/course-zoomcamp/11-kserve/07-kserve-eks-upd.md
+++ b/course-zoomcamp/11-kserve/07-kserve-eks-upd.md
@@ -1,4 +1,4 @@
-## Deploying with KServe and EKS - Update (09 July, 2022)
+## Deploying with KServe and EKS - Update (13 July, 2022)
 
 (These instructions assume that the user does not own a custom domain.)  
 

--- a/course-zoomcamp/11-kserve/07-kserve-eks.md
+++ b/course-zoomcamp/11-kserve/07-kserve-eks.md
@@ -11,7 +11,6 @@
 
 Add notes from the video (PRs are welcome)
 
-
 <table>
    <tr>
       <td>⚠️</td>
@@ -22,6 +21,8 @@ Add notes from the video (PRs are welcome)
    </tr>
 </table>
 
+### Updated Instructions (13 July, 2022)   
+See [the instructions here](07-kserve-eks-upd.md)
 
 ## Nagivation
 


### PR DESCRIPTION
This PR
- assumes that the user does not have a custom domain
- fixes issues in EKS related to version (kserve requires k8s 1.21.1)