### PR TITLE
Update 08-ohe.md

### DIFF
--- a/course-zoomcamp/03-classification/08-ohe.md
+++ b/course-zoomcamp/03-classification/08-ohe.md
@@ -14,7 +14,7 @@ One-Hot Encoding allows encoding categorical variables in numerical ones. This m
 
 * `df[x].to_dict(oriented='records')` - convert x series to dictionaries, oriented by rows. 
 * `DictVectorizer().fit_transform(x)` - Scikit-Learn class for converting x dictionaries into a sparse matrix, and in this way doing the one-hot encoding. It does not affect the numerical variables. 
-* `DictVectorizer().get_feature_names()` -  returns the names of the columns in the sparse matrix.  
+* `DictVectorizer().get_feature_names_out()` -  returns the names of the columns in the matrix/sparse matrix.  
 
 The entire code of this project is available in [this jupyter notebook](https://github.com/alexeygrigorev/mlbookcamp-code/blob/master/chapter-03-churn-prediction/03-churn.ipynb). 
 


### PR DESCRIPTION
Function get_feature_names is deprecated; 
get_feature_names is deprecated in 1.0 and will be removed in 1.2.  Please use get_feature_names_out instead.