### PR TITLE
Updated 06. environment.md in first week of mlzoomcamp 

### DIFF
--- a/course-zoomcamp/01-intro/06-environment.md
+++ b/course-zoomcamp/01-intro/06-environment.md
@@ -9,16 +9,20 @@ You need:
 * NumPy, Pandas and Scikit-Learn (latest available versions) 
 * Matplotlib and Seaborn
 * Jupyter notebooks
+* Later on, we'll need docker and preferably AWS for AWS lambda, Kubernetes, Kserve etc
+### Summary
+
+|Name of ML platform| Supports basic ML: Chapter 1-4 | Supports deployment with docker locally: Chapter 5 | Supports docker deployment to Cloud: Chapter 9-11 | Guides |
+|-------|-------|-------|-------|------|
+|Windows - with Pipenv or Anaconda, Anaconda preferred | :white_check_mark: | :x: | :x: | [Getting started with Anaconda](#Anaconda)|
+|Windows with WSL - with Pipenv or Anaconda, Anaconda preferred| :white_check_mark: | :white_check_mark: | :x: | [Setting up WSL on windows](#Ubuntu_on_AWS)  
+|MacOS (Basically built on a Unix OS, so usually supports whatever Linux supports as Linux is a Unix-like OS)- with Pipenv or Anaconda, Anaconda preferred | :white_check_mark: | :white_check_mark: | :x: | [Getting started with Anaconda](#Anaconda)
+|Ubuntu / Linux - with Pipenv or Anaconda, Anaconda preferred| :white_check_mark: | :white_check_mark: | :x: | [Guide for using Anaconda](#Anaconda)
+|Work completely online & OS independent - Simple ML: Kaggle and Colab| :white_check_mark: | :x: | :x: | [Getting started with Kaggle / Colab](#Notebook_services)
+|Work in local terminal in any OS, whereas backend is cloud. Esp useful for slow systems that have less than required RAM/GPU - Advanced ML, esp deployment: AWS, GCP or Azure. Please note that the OS you should select in any cloud platform is Ubuntu/any other Linux disto| :white_check_mark: | :white_check_mark:| :white_check_mark: | [Setting up Ubuntu on AWS](#Ubuntu_on_AWS)  
 
 
-## Ubuntu 22.04 on AWS
-
-* [This video](https://www.youtube.com/watch?v=IXSiYkP23zo) shows a complete end-to-end environment configuration for an AWS EC2 instance
-* This video was created for another course (MLOps Zoomcamp), so you'll need to adjust it slightly: clone this repo instead of the mlops one
-* You can use these instructions for setting up your local Ubuntu or Ubuntu in WSL
-
-
-## Anaconda and Conda
+## [Anaconda and Conda](Anaconda)
 
 The easiest way to set up the environment is to use [Anaconda](https://www.anaconda.com/products/individual) or
 [Miniconda](https://docs.conda.io/en/latest/miniconda.html).
@@ -41,7 +45,7 @@ Anaconda is recommended.
 
 It is a good idea to set up a dedicated environment for the course 
 
-In your terminal, run this command to create the environment
+In your terminal (e.g bash for Ubuntu, anaconda command prompt for windows), run this command to create the environment
 
 ```bash
 conda create -n ml-zoomcamp python=3.9
@@ -62,25 +66,7 @@ conda install numpy pandas scikit-learn seaborn jupyter
 Later in the course you will also need to install XGBoost and Tensorflow,
 but we can skip this part for now.
 
-## Cloud
-
-Instead of running things locally, you can use online services or rent a server 
-
-### AWS 
-
-You can rent an instance on AWS:
-
-* [Creating an AWS account](https://mlbookcamp.com/article/aws)
-* [Renting an ec2 instance](https://mlbookcamp.com/article/aws-ec2)
-
-
-### GCP
-
-Google cloud platform offers $300 in free credits when you sign up.
-You can use this for taking the course.
-
-
-## Notebook services
+## [Notebook services](Notebook_services)
 
 There are services that allow you to host and run notebooks.
 Note that notebooks alone are not sufficient for the course and for the deployment modules
@@ -130,6 +116,32 @@ Steps for Google Colab are same as that for Kaggle, except for some changes in S
 2. To open the notebook in Google Colab, in your web browser launch paste the URL as shown in below example. (*note the https://github.com/ in the URL of the notebook is replaced by https://colab.research.google.com/github/*)
 
    https://colab.research.google.com/github/alexeygrigorev/mlbookcamp-code/blob/master/chapter-02-car-price/02-carprice.ipynb
+
+
+## Cloud
+
+Instead of running things locally, you can use online services or rent a server 
+
+### AWS 
+
+You can rent an instance on AWS:
+
+* [Creating an AWS account](https://mlbookcamp.com/article/aws)
+* [Renting an ec2 instance](https://mlbookcamp.com/article/aws-ec2)
+
+#### [Ubuntu 22.04 on AWS](Ubuntu_on_AWS)
+
+* [This video](https://www.youtube.com/watch?v=IXSiYkP23zo) shows a complete end-to-end environment configuration for an AWS EC2 instance
+* This video was created for another course (MLOps Zoomcamp), so you'll need to adjust it slightly: clone this repo instead of the mlops one
+* You can use these instructions for setting up your local Ubuntu or Ubuntu in WSL
+
+
+
+### GCP
+
+Google cloud platform offers $300 in free credits when you sign up.
+You can use this for taking the course.
+
 
 
 

--- a/course-zoomcamp/01-intro/06-environment.md
+++ b/course-zoomcamp/01-intro/06-environment.md
@@ -14,15 +14,15 @@ You need:
 
 |Name of ML platform| Supports basic ML: Chapter 1-4 | Supports deployment with docker locally: Chapter 5 | Supports docker deployment to Cloud: Chapter 9-11 | Guides |
 |-------|-------|-------|-------|------|
-|Windows - with Pipenv or Anaconda, Anaconda preferred | :white_check_mark: | :x: | :x: | [Getting started with Anaconda](#Anaconda)|
-|Windows with WSL - with Pipenv or Anaconda, Anaconda preferred| :white_check_mark: | :white_check_mark: | :x: | [Setting up docker with WSL on windows](#Ubuntu_on_AWS)  
-|MacOS (Basically built on a Unix OS, so usually supports whatever Linux supports as Linux is a Unix-like OS)- with Pipenv or Anaconda, Anaconda preferred | :white_check_mark: | :white_check_mark: | :x: | [Getting started with Anaconda](#Anaconda)
-|Ubuntu / Linux - with Pipenv or Anaconda, Anaconda preferred| :white_check_mark: | :white_check_mark: | :x: | [Getting started with Anaconda](#Anaconda)
-|Work completely online & OS independent - Useful for simple ML and light-weight deep learning: Kaggle and Colab| :white_check_mark: | :x: | :x: | [Getting started with Kaggle / Colab](#Notebook_services)
-|Work in local terminal in any OS, whereas backend is cloud. Esp useful for slow systems that have less than required RAM/GPU - Useful for for AutoML, Advanced ML, heavy-duty deep learning, esp deployment.<br/><br/> Common ML on cloud service providers: AWS, GCP or Azure. Please note that the OS you should select in any cloud platform is Ubuntu/any other Linux disto| :white_check_mark: | :white_check_mark:| :white_check_mark: | [Setting up Ubuntu on AWS](#Ubuntu_on_AWS)  
+|Windows - with Pipenv or Anaconda, Anaconda preferred | :white_check_mark: | :x: | :x: | [Getting started with Anaconda](#anaconda_and_conda)|
+|Windows with WSL - with Pipenv or Anaconda, Anaconda preferred| :white_check_mark: | :white_check_mark: | :x: | [Setting up docker with WSL on windows](#ubuntu_22.04_on_aws)  
+|MacOS (Basically built on a Unix OS, so usually supports whatever Linux supports as Linux is a Unix-like OS)- with Pipenv or Anaconda, Anaconda preferred | :white_check_mark: | :white_check_mark: | :x: | [Getting started with Anaconda](#anaconda_and_conda)
+|Ubuntu / Linux - with Pipenv or Anaconda, Anaconda preferred| :white_check_mark: | :white_check_mark: | :x: | [Getting started with Anaconda](#anaconda_and_conda)
+|Work completely online & OS independent - Useful for simple ML and light-weight deep learning: Kaggle and Colab| :white_check_mark: | :x: | :x: | [Getting started with Kaggle / Colab](#notebook_services)
+|Work in local terminal in any OS, whereas backend is cloud. Esp useful for slow systems that have less than required RAM/GPU - Useful for for AutoML, Advanced ML, heavy-duty deep learning, esp deployment.<br/><br/> Common ML on cloud service providers: AWS, GCP or Azure. Please note that the OS you should select in any cloud platform is Ubuntu/any other Linux disto| :white_check_mark: | :white_check_mark:| :white_check_mark: | [Setting up Ubuntu on AWS](#ubuntu_22.04_on_aws)  
 
 
-## [Anaconda and Conda](Anaconda)
+## [Anaconda and Conda](anaconda_and_conda)
 
 The easiest way to set up the environment is to use [Anaconda](https://www.anaconda.com/products/individual) or
 [Miniconda](https://docs.conda.io/en/latest/miniconda.html).
@@ -66,7 +66,7 @@ conda install numpy pandas scikit-learn seaborn jupyter
 Later in the course you will also need to install XGBoost and Tensorflow,
 but we can skip this part for now.
 
-## [Notebook services](Notebook_services)
+## [Notebook services](notebook_services)
 
 There are services that allow you to host and run notebooks.
 Note that notebooks alone are not sufficient for the course and for the deployment modules
@@ -129,7 +129,7 @@ You can rent an instance on AWS:
 * [Creating an AWS account](https://mlbookcamp.com/article/aws)
 * [Renting an ec2 instance](https://mlbookcamp.com/article/aws-ec2)
 
-#### [Ubuntu 22.04 on AWS](Ubuntu_on_AWS)
+#### [Ubuntu 22.04 on AWS](ubuntu_22.04_on_aws)
 
 * [This video](https://www.youtube.com/watch?v=IXSiYkP23zo) shows a complete end-to-end environment configuration for an AWS EC2 instance
 * This video was created for another course (MLOps Zoomcamp), so you'll need to adjust it slightly: clone this repo instead of the mlops one

--- a/course-zoomcamp/01-intro/06-environment.md
+++ b/course-zoomcamp/01-intro/06-environment.md
@@ -15,11 +15,11 @@ You need:
 |Name of ML platform| Supports basic ML: Chapter 1-4 | Supports deployment with docker locally: Chapter 5 | Supports docker deployment to Cloud: Chapter 9-11 | Guides |
 |-------|-------|-------|-------|------|
 |Windows - with Pipenv or Anaconda, Anaconda preferred | :white_check_mark: | :x: | :x: | [Getting started with Anaconda](#anaconda-and-conda)|
-|Windows with WSL - with Pipenv or Anaconda, Anaconda preferred| :white_check_mark: | :white_check_mark: | :x: | [Setting up docker with WSL on windows](#ubuntu-on_aws)  
+|Windows with WSL - with Pipenv or Anaconda, Anaconda preferred| :white_check_mark: | :white_check_mark: | :x: | [Setting up docker with WSL on windows](#ubuntu-on-aws)  
 |MacOS (Basically built on a Unix OS, so usually supports whatever Linux supports as Linux is a Unix-like OS)- with Pipenv or Anaconda, Anaconda preferred | :white_check_mark: | :white_check_mark: | :x: | [Getting started with Anaconda](#anaconda-and-conda)
 |Ubuntu / Linux - with Pipenv or Anaconda, Anaconda preferred| :white_check_mark: | :white_check_mark: | :x: | [Getting started with Anaconda](#anaconda-and-conda)
 |Work completely online & OS independent - Useful for simple ML and light-weight deep learning: Kaggle and Colab| :white_check_mark: | :x: | :x: | [Getting started with Kaggle / Colab](#notebook-services)
-|Work in local terminal in any OS, whereas backend is cloud. Esp useful for slow systems that have less than required RAM/GPU - Useful for for AutoML, Advanced ML, heavy-duty deep learning, esp deployment.<br/><br/> Common ML on cloud service providers: AWS, GCP or Azure. Please note that the OS you should select in any cloud platform is Ubuntu/any other Linux disto| :white_check_mark: | :white_check_mark:| :white_check_mark: | [Setting up Ubuntu on AWS](#ubuntu-on_aws)  
+|Work in local terminal in any OS, whereas backend is cloud. Esp useful for slow systems that have less than required RAM/GPU - Useful for for AutoML, Advanced ML, heavy-duty deep learning, esp deployment.<br/><br/> Common ML on cloud service providers: AWS, GCP or Azure. Please note that the OS you should select in any cloud platform is Ubuntu/any other Linux disto| :white_check_mark: | :white_check_mark:| :white_check_mark: | [Setting up Ubuntu on AWS](#ubuntu-on-aws)  
 
 
 ## [Anaconda and Conda](anaconda-and-conda)

--- a/course-zoomcamp/01-intro/06-environment.md
+++ b/course-zoomcamp/01-intro/06-environment.md
@@ -15,11 +15,11 @@ You need:
 |Name of ML platform| Supports basic ML: Chapter 1-4 | Supports deployment with docker locally: Chapter 5 | Supports docker deployment to Cloud: Chapter 9-11 | Guides |
 |-------|-------|-------|-------|------|
 |Windows - with Pipenv or Anaconda, Anaconda preferred | :white_check_mark: | :x: | :x: | [Getting started with Anaconda](#Anaconda)|
-|Windows with WSL - with Pipenv or Anaconda, Anaconda preferred| :white_check_mark: | :white_check_mark: | :x: | [Setting up WSL on windows](#Ubuntu_on_AWS)  
+|Windows with WSL - with Pipenv or Anaconda, Anaconda preferred| :white_check_mark: | :white_check_mark: | :x: | [Setting up docker with WSL on windows](#Ubuntu_on_AWS)  
 |MacOS (Basically built on a Unix OS, so usually supports whatever Linux supports as Linux is a Unix-like OS)- with Pipenv or Anaconda, Anaconda preferred | :white_check_mark: | :white_check_mark: | :x: | [Getting started with Anaconda](#Anaconda)
-|Ubuntu / Linux - with Pipenv or Anaconda, Anaconda preferred| :white_check_mark: | :white_check_mark: | :x: | [Guide for using Anaconda](#Anaconda)
-|Work completely online & OS independent - Simple ML: Kaggle and Colab| :white_check_mark: | :x: | :x: | [Getting started with Kaggle / Colab](#Notebook_services)
-|Work in local terminal in any OS, whereas backend is cloud. Esp useful for slow systems that have less than required RAM/GPU - Advanced ML, esp deployment: AWS, GCP or Azure. Please note that the OS you should select in any cloud platform is Ubuntu/any other Linux disto| :white_check_mark: | :white_check_mark:| :white_check_mark: | [Setting up Ubuntu on AWS](#Ubuntu_on_AWS)  
+|Ubuntu / Linux - with Pipenv or Anaconda, Anaconda preferred| :white_check_mark: | :white_check_mark: | :x: | [Getting started with Anaconda](#Anaconda)
+|Work completely online & OS independent - Useful for simple ML and light-weight deep learning: Kaggle and Colab| :white_check_mark: | :x: | :x: | [Getting started with Kaggle / Colab](#Notebook_services)
+|Work in local terminal in any OS, whereas backend is cloud. Esp useful for slow systems that have less than required RAM/GPU - Useful for for AutoML, Advanced ML, heavy-duty deep learning, esp deployment.<br/><br/> Common ML on cloud service providers: AWS, GCP or Azure. Please note that the OS you should select in any cloud platform is Ubuntu/any other Linux disto| :white_check_mark: | :white_check_mark:| :white_check_mark: | [Setting up Ubuntu on AWS](#Ubuntu_on_AWS)  
 
 
 ## [Anaconda and Conda](Anaconda)
@@ -133,7 +133,7 @@ You can rent an instance on AWS:
 
 * [This video](https://www.youtube.com/watch?v=IXSiYkP23zo) shows a complete end-to-end environment configuration for an AWS EC2 instance
 * This video was created for another course (MLOps Zoomcamp), so you'll need to adjust it slightly: clone this repo instead of the mlops one
-* You can use these instructions for setting up your local Ubuntu or Ubuntu in WSL
+* You can use these instructions for setting up docker with your local Ubuntu or Ubuntu in WSL 
 
 
 

--- a/course-zoomcamp/01-intro/06-environment.md
+++ b/course-zoomcamp/01-intro/06-environment.md
@@ -14,15 +14,15 @@ You need:
 
 |Name of ML platform| Supports basic ML: Chapter 1-4 | Supports deployment with docker locally: Chapter 5 | Supports docker deployment to Cloud: Chapter 9-11 | Guides |
 |-------|-------|-------|-------|------|
-|Windows - with Pipenv or Anaconda, Anaconda preferred | :white_check_mark: | :x: | :x: | [Getting started with Anaconda](#anaconda_and_conda)|
-|Windows with WSL - with Pipenv or Anaconda, Anaconda preferred| :white_check_mark: | :white_check_mark: | :x: | [Setting up docker with WSL on windows](#ubuntu_22.04_on_aws)  
-|MacOS (Basically built on a Unix OS, so usually supports whatever Linux supports as Linux is a Unix-like OS)- with Pipenv or Anaconda, Anaconda preferred | :white_check_mark: | :white_check_mark: | :x: | [Getting started with Anaconda](#anaconda_and_conda)
-|Ubuntu / Linux - with Pipenv or Anaconda, Anaconda preferred| :white_check_mark: | :white_check_mark: | :x: | [Getting started with Anaconda](#anaconda_and_conda)
-|Work completely online & OS independent - Useful for simple ML and light-weight deep learning: Kaggle and Colab| :white_check_mark: | :x: | :x: | [Getting started with Kaggle / Colab](#notebook_services)
-|Work in local terminal in any OS, whereas backend is cloud. Esp useful for slow systems that have less than required RAM/GPU - Useful for for AutoML, Advanced ML, heavy-duty deep learning, esp deployment.<br/><br/> Common ML on cloud service providers: AWS, GCP or Azure. Please note that the OS you should select in any cloud platform is Ubuntu/any other Linux disto| :white_check_mark: | :white_check_mark:| :white_check_mark: | [Setting up Ubuntu on AWS](#ubuntu_22.04_on_aws)  
+|Windows - with Pipenv or Anaconda, Anaconda preferred | :white_check_mark: | :x: | :x: | [Getting started with Anaconda](#anaconda-and-conda)|
+|Windows with WSL - with Pipenv or Anaconda, Anaconda preferred| :white_check_mark: | :white_check_mark: | :x: | [Setting up docker with WSL on windows](#ubuntu-on_aws)  
+|MacOS (Basically built on a Unix OS, so usually supports whatever Linux supports as Linux is a Unix-like OS)- with Pipenv or Anaconda, Anaconda preferred | :white_check_mark: | :white_check_mark: | :x: | [Getting started with Anaconda](#anaconda-and-conda)
+|Ubuntu / Linux - with Pipenv or Anaconda, Anaconda preferred| :white_check_mark: | :white_check_mark: | :x: | [Getting started with Anaconda](#anaconda-and-conda)
+|Work completely online & OS independent - Useful for simple ML and light-weight deep learning: Kaggle and Colab| :white_check_mark: | :x: | :x: | [Getting started with Kaggle / Colab](#notebook-services)
+|Work in local terminal in any OS, whereas backend is cloud. Esp useful for slow systems that have less than required RAM/GPU - Useful for for AutoML, Advanced ML, heavy-duty deep learning, esp deployment.<br/><br/> Common ML on cloud service providers: AWS, GCP or Azure. Please note that the OS you should select in any cloud platform is Ubuntu/any other Linux disto| :white_check_mark: | :white_check_mark:| :white_check_mark: | [Setting up Ubuntu on AWS](#ubuntu-on_aws)  
 
 
-## [Anaconda and Conda](anaconda_and_conda)
+## [Anaconda and Conda](anaconda-and-conda)
 
 The easiest way to set up the environment is to use [Anaconda](https://www.anaconda.com/products/individual) or
 [Miniconda](https://docs.conda.io/en/latest/miniconda.html).
@@ -66,7 +66,7 @@ conda install numpy pandas scikit-learn seaborn jupyter
 Later in the course you will also need to install XGBoost and Tensorflow,
 but we can skip this part for now.
 
-## [Notebook services](notebook_services)
+## [Notebook services](notebook-services)
 
 There are services that allow you to host and run notebooks.
 Note that notebooks alone are not sufficient for the course and for the deployment modules
@@ -129,7 +129,7 @@ You can rent an instance on AWS:
 * [Creating an AWS account](https://mlbookcamp.com/article/aws)
 * [Renting an ec2 instance](https://mlbookcamp.com/article/aws-ec2)
 
-#### [Ubuntu 22.04 on AWS](ubuntu_22.04_on_aws)
+#### [Ubuntu on AWS](ubuntu-on-aws)
 
 * [This video](https://www.youtube.com/watch?v=IXSiYkP23zo) shows a complete end-to-end environment configuration for an AWS EC2 instance
 * This video was created for another course (MLOps Zoomcamp), so you'll need to adjust it slightly: clone this repo instead of the mlops one

--- a/course-zoomcamp/01-intro/08-linear-algebra.md
+++ b/course-zoomcamp/01-intro/08-linear-algebra.md
@@ -99,7 +99,6 @@ inv = np.linalg.inv(V)
 
 
 Add notes here (PRs are welcome).
-
 <table>
    <tr>
       <td>⚠️</td>
@@ -114,6 +113,7 @@ Add notes here (PRs are welcome).
 
 * [Notebook from the video](notebooks/08-linear-algebra.ipynb)
 * [Get a visual understanding of matrix multiplication](http://matrixmultiplication.xyz/)
+* [Overview of matrix multiplication functions in python/numpy + exploring commutative property and normal equation](https://github.com/MemoonaTahira/MLZoomcamp2022/blob/main/Notes/Notes_for_Chapter_1-Linear_Algebra.ipynb) 
 
 
 ## Navigation

--- a/course-zoomcamp/02-regression/README.md
+++ b/course-zoomcamp/02-regression/README.md
@@ -31,4 +31,5 @@ Did you take notes? You can share them here (or in each unit separately)
 * [Notes form Ayoub Berdeddouch](https://github.com/ayoub-berdeddouch/mlbookcamp-homeworks/blob/main/Regression/homework_Regression_AyoubBerdeddouch.ipynb)
 * [Notes from Alvaro Navas](https://github.com/ziritrion/ml-zoomcamp/blob/main/notes/02_linear_regression.md)
 * [Notes from froukje](https://github.com/froukje/ml-zoomcamp/blob/main/week2/Lecture_2_car_price_prediction.ipynb)
+* [Notes from Memoona Tahira](https://github.com/MemoonaTahira/MLZoomcamp2022/blob/main/Notes/readme.md#week-12-overview-structuring-a-machine-learning-project)
 * Add your notes here


### PR DESCRIPTION
1. I created a summary table with markdown links to the notes below to better determine what someone can use for ML. 

I kept order from learning locally (windows, windows wsl, macOS and ubuntu) to online via kaggle/colab and cloud services.

I wanted to add Heroku as a deployment service only, unlike a full fledged cloud provider with training environments, but I don't know much about it. It can be added after last row in the summary table with notes.


2. Added notes to 08-Linear Algebra for week 1

3. Added notes to week 2 for overview of work done so far