### PR TITLE
Jon Areas' notes for Module 2

### DIFF
--- a/course-zoomcamp/02-regression/README.md
+++ b/course-zoomcamp/02-regression/README.md
@@ -25,7 +25,6 @@
 
 Did you take notes? You can share them here (or in each unit separately)
 
-* [Notes from Edward](https://edwardcodes.github.io/posts/lr-normal-equation/)
 * [Notes from Kwang Yang](https://www.kaggle.com/kwangyangchia/notebook-for-lesson-2-mle)
 * [Notes from Sebastián Ayala Ruano](https://github.com/sayalaruano/100DaysOfMLCode/blob/main/Regression/Notes/NotesDay5.md)
 * [Notes form Ayoub Berdeddouch](https://github.com/ayoub-berdeddouch/mlbookcamp-homeworks/blob/main/Regression/homework_Regression_AyoubBerdeddouch.ipynb)

--- a/course-zoomcamp/02-regression/README.md
+++ b/course-zoomcamp/02-regression/README.md
@@ -27,7 +27,8 @@ Did you take notes? You can share them here (or in each unit separately)
 
 * [Notes from Kwang Yang](https://www.kaggle.com/kwangyangchia/notebook-for-lesson-2-mle)
 * [Notes from Sebastián Ayala Ruano](https://github.com/sayalaruano/100DaysOfMLCode/blob/main/Regression/Notes/NotesDay5.md)
-* [Notes form Ayoub Berdeddouch](https://github.com/ayoub-berdeddouch/mlbookcamp-homeworks/blob/main/Regression/homework_Regression_AyoubBerdeddouch.ipynb)
+* [Notes from Ayoub Berdeddouch](https://github.com/ayoub-berdeddouch/mlbookcamp-homeworks/blob/main/Regression/homework_Regression_AyoubBerdeddouch.ipynb)
 * [Notes from Alvaro Navas](https://github.com/ziritrion/ml-zoomcamp/blob/main/notes/02_linear_regression.md)
 * [Notes from froukje](https://github.com/froukje/ml-zoomcamp/blob/main/week2/Lecture_2_car_price_prediction.ipynb)
+* [Notes from Jon Areas](https://github.com/jxareas/Machine-Learning-Bookcamp-2022/blob/master/notes/02-regression.md)
 * Add your notes here


### PR DESCRIPTION
- [Removed Edwards' notes from the Regression Zoomcamp module, as they return a page not found error](https://edwardcodes.github.io/posts/lr-normal-equation/).
- Added my notes to the 2nd Zoomcamp Module.
- Fixed a typo.