### PR TITLE
Fix: missing variable in 05-deployment train-churn-model.

### DIFF
--- a/05-deployment/code/05-train-churn-model.ipynb
+++ b/05-deployment/code/05-train-churn-model.ipynb
@@ -214,6 +214,7 @@
     "dv, model = train(df_full_train, df_full_train.churn.values, C=1.0)\n",
     "y_pred = predict(df_test, dv, model)\n",
     "\n",
+    "y_test = df_test.churn.values\n",
     "auc = roc_auc_score(y_test, y_pred)\n",
     "auc"
    ]


### PR DESCRIPTION
This commit fixes the missing variable in the notebook `05-train-churn-model.ipynb` where there was missing the variable `y_test`.