### PR TITLE
docs: add 2025 cohort homework reference to intro module

### DIFF
--- a/01-intro/homework.md
+++ b/01-intro/homework.md
@@ -1,5 +1,6 @@
 ## Homework
 
+* For 2025 cohort homework, check [the 2025 cohort folder](../cohorts/2025/01-intro/homework.md)
 * For 2024 cohort homework, check [the 2024 cohort folder](../cohorts/2024/01-intro/homework.md)
 * For 2023 cohort homework, check [the 2023 cohort folder](../cohorts/2023/01-intro/homework.md)
 * For 2022 cohort homework, check [the 2022 cohort folder](../cohorts/2022/01-intro/homework.md)

--- a/cohorts/2025/01-intro/homework.md
+++ b/cohorts/2025/01-intro/homework.md
@@ -104,5 +104,5 @@ Has it changed?
 
 ## Submit the results
 
-* Submit your results here: https://courses.datatalks.club/ml-zoomcamp-2025/homework/hw02
+* Submit your results here: https://courses.datatalks.club/ml-zoomcamp-2025/homework/hw01
 * If your answer doesn't match options exactly, select the closest one


### PR DESCRIPTION
- Add link to 2025 cohort homework folder in 01-intro/homework.md
- Maintains consistency with existing cohort homework references
- Helps students find the most current homework assignments