### PR TITLE
Fix: Updating Homework.md for W2, W3, and W4 for 2025 cohort

### DIFF
--- a/02-regression/homework.md
+++ b/02-regression/homework.md
@@ -1,5 +1,5 @@
 ## Homework
-
+* For 2025 cohort homework, check [the 2025 cohort folder](../cohorts/2025/02-regression/homework.md)
 * For 2024 cohort homework, check [the 2024 cohort folder](../cohorts/2024/02-regression/homework.md)
 * For 2023 cohort homework, check [the 2023 cohort folder](../cohorts/2023/02-regression/homework.md)
 * For 2022 cohort homework, check [the 2022 cohort folder](../cohorts/2022/02-regression/homework.md)

--- a/03-classification/homework.md
+++ b/03-classification/homework.md
@@ -1,5 +1,5 @@
 ## Homework
-
+* For 2025 cohort homework, check [the 2025 cohort folder](../cohorts/2025/03-classification/homework.md)
 * For 2024 cohort homework, check [the 2024 cohort folder](../cohorts/2024/03-classification/homework.md)
 * For 2023 cohort homework, check [the 2023 cohort folder](../cohorts/2023/03-classification/homework.md)
 * For 2022 cohort homework, check [the 2022 cohort folder](../cohorts/2022/03-classification/homework.md)

--- a/04-evaluation/homework.md
+++ b/04-evaluation/homework.md
@@ -1,5 +1,5 @@
 ## Homework
-
+* For 2025 cohort homework, check [the 2025 cohort folder](../cohorts/2025/04-evaluation/homework.md)
 * For 2024 cohort homework, check [the 2024 cohort folder](../cohorts/2024/04-evaluation/homework.md)
 * For 2023 cohort homework, check [the 2023 cohort folder](../cohorts/2023/04-evaluation/homework.md)
 * For 2022 cohort homework, check [the 2022 cohort folder](../cohorts/2022/04-evaluation/homework.md)


### PR DESCRIPTION
### Summary
Updates **Homework.md** links for **Weeks 2, 3, and 4** to reflect the **2025 cohort**. Previously, these sections only referenced the 2024 cohort.

### Changes
- Added 2025 cohort homework links for:
  - Week 2
  - Week 3
  - Week 4
- Ensured formatting is consistent with existing 2024 cohort links.

### Rationale
This update helps new students in the 2025 cohort easily find the correct homework assignments, avoiding confusion with outdated 2024 links.

### Notes
- No changes were made to code or other documentation.
- Verified that markdown renders correctly.
