### PR TITLE
fix: update notebook link in module 3 to updated notebook

### DIFF
--- a/03-classification/02-data-preparation.md
+++ b/03-classification/02-data-preparation.md
@@ -25,7 +25,7 @@ This session covered data obtention and some procedures of data preparation.
 * `df.fillna()` - replace NAs with some value 
 * `(df.x == "yes").astype(int)` - convert x series of yes-no values to numerical values. 
 
-The entire code of this project is available in [this jupyter notebook](https://github.com/alexeygrigorev/mlbookcamp-code/blob/master/chapter-03-churn-prediction/03-churn.ipynb).
+The entire code of this project is available in [this jupyter notebook](https://github.com/DataTalksClub/machine-learning-zoomcamp/blob/master/03-classification/notebook.ipynb).
 
 
 <table>

--- a/03-classification/03-validation.md
+++ b/03-classification/03-validation.md
@@ -17,7 +17,7 @@ Splitting the dataset with **Scikit-Learn**.
 * `df.x.values` - extract the values from x series
 * `del df['x']` - delete x series from a dataframe 
 
-The entire code of this project is available in [this jupyter notebook](https://github.com/alexeygrigorev/mlbookcamp-code/blob/master/chapter-03-churn-prediction/03-churn.ipynb).
+The entire code of this project is available in [this jupyter notebook](https://github.com/DataTalksClub/machine-learning-zoomcamp/blob/master/03-classification/notebook.ipynb).
 
 <table>
    <tr>

--- a/03-classification/04-eda.md
+++ b/03-classification/04-eda.md
@@ -20,7 +20,7 @@ The EDA for this project consisted of:
 * `round(x, y)` - round an x number with y decimal places
 * `df[x].nunique()` - returns the number of unique values in x series 
 
-The entire code of this project is available in [this jupyter notebook](https://github.com/alexeygrigorev/mlbookcamp-code/blob/master/chapter-03-churn-prediction/03-churn.ipynb). 
+The entire code of this project is available in [this jupyter notebook](https://github.com/DataTalksClub/machine-learning-zoomcamp/blob/master/03-classification/notebook.ipynb). 
 
 <table>
    <tr>

--- a/03-classification/05-risk.md
+++ b/03-classification/05-risk.md
@@ -17,7 +17,7 @@
 * `df.groupby('x').y.agg([mean()])` - returns a dataframe with mean of y series grouped by x series 
 * `display(x)` displays an output in the cell of a jupyter notebook. 
 
-The entire code of this project is available in [this jupyter notebook](https://github.com/alexeygrigorev/mlbookcamp-code/blob/master/chapter-03-churn-prediction/03-churn.ipynb). 
+The entire code of this project is available in [this jupyter notebook](https://github.com/DataTalksClub/machine-learning-zoomcamp/blob/master/03-classification/notebook.ipynb). 
 
 
 <table>

--- a/03-classification/06-mutual-info.md
+++ b/03-classification/06-mutual-info.md
@@ -16,7 +16,7 @@ Mutual information is a concept from information theory, which measures how much
 * `df[x].apply(y)` - apply a y function to the x series of the df dataframe. 
 * ` df.sort_values(ascending=False).to_frame(name='x')` - sort values in an ascending order and called the column as x. 
 
-The entire code of this project is available in [this jupyter notebook](https://github.com/alexeygrigorev/mlbookcamp-code/blob/master/chapter-03-churn-prediction/03-churn.ipynb). 
+The entire code of this project is available in [this jupyter notebook](https://github.com/DataTalksClub/machine-learning-zoomcamp/blob/master/03-classification/notebook.ipynb). 
 
 <table>
    <tr>

--- a/03-classification/07-correlation.md
+++ b/03-classification/07-correlation.md
@@ -25,7 +25,7 @@ Positive Correlation vs. Negative Correlation
 
 * `df[x].corrwith(y)` - returns the correlation between x and y series. This is a function from pandas.
 
-The entire code of this project is available in [this jupyter notebook](https://github.com/alexeygrigorev/mlbookcamp-code/blob/master/chapter-03-churn-prediction/03-churn.ipynb).
+The entire code of this project is available in [this jupyter notebook](https://github.com/DataTalksClub/machine-learning-zoomcamp/blob/master/03-classification/notebook.ipynb).
 
 <table>
    <tr>

--- a/03-classification/08-ohe.md
+++ b/03-classification/08-ohe.md
@@ -16,7 +16,7 @@ One-Hot Encoding allows encoding categorical variables in numerical ones. This m
 * `DictVectorizer().fit_transform(x)` - Scikit-Learn class for one-hot encoding by converting x dictionaries into a sparse matrix. It does not affect the numerical variables. 
 * `DictVectorizer().get_feature_names()` -  return the names of the columns in the sparse matrix.  
 
-The entire code of this project is available in [this jupyter notebook](https://github.com/alexeygrigorev/mlbookcamp-code/blob/master/chapter-03-churn-prediction/03-churn.ipynb). 
+The entire code of this project is available in [this jupyter notebook](https://github.com/DataTalksClub/machine-learning-zoomcamp/blob/master/03-classification/notebook.ipynb). 
 
 <table>
    <tr>

--- a/03-classification/09-logistic-regression.md
+++ b/03-classification/09-logistic-regression.md
@@ -28,7 +28,7 @@ Logistic regression is similar to linear regression because both models take int
 
 In this way, the sigmoid function allows transforming a score into a probability. 
 
-The entire code of this project is available in [this jupyter notebook](https://github.com/alexeygrigorev/mlbookcamp-code/blob/master/chapter-03-churn-prediction/03-churn.ipynb). 
+The entire code of this project is available in [this jupyter notebook](https://github.com/DataTalksClub/machine-learning-zoomcamp/blob/master/03-classification/notebook.ipynb). 
 
 <table>
    <tr>

--- a/03-classification/10-training-log-reg.md
+++ b/03-classification/10-training-log-reg.md
@@ -18,7 +18,7 @@ This video was about training a logistic regression model with Scikit-Learn, app
 * `LogisticRegression().predict[x]` - make predictions on the x dataset 
 * `LogisticRegression().predict_proba[x]` - make predictions on the x dataset by returning two columns with their probabilities for the two categories - soft predictions 
 
-The entire code of this project is available in [this jupyter notebook](https://github.com/alexeygrigorev/mlbookcamp-code/blob/master/chapter-03-churn-prediction/03-churn.ipynb).
+The entire code of this project is available in [this jupyter notebook](https://github.com/DataTalksClub/machine-learning-zoomcamp/blob/master/03-classification/notebook.ipynb).
 
 <table>
    <tr>

--- a/03-classification/11-log-reg-interpretation.md
+++ b/03-classification/11-log-reg-interpretation.md
@@ -16,7 +16,7 @@ In the formula of the logistic regression model, only one of the one-hot encoded
 
 * `zip(x,y)` - returns a new list with elements from x joined with their corresponding elements on y 
 
-The entire code of this project is available in [this jupyter notebook](https://github.com/alexeygrigorev/mlbookcamp-code/blob/master/chapter-03-churn-prediction/03-churn.ipynb). 
+The entire code of this project is available in [this jupyter notebook](https://github.com/DataTalksClub/machine-learning-zoomcamp/blob/master/03-classification/notebook.ipynb). 
 
 <table>
    <tr>


### PR DESCRIPTION
Description:
Corrected a link to the notebook in module 3.

Previous Link: https://github.com/alexeygrigorev/mlbookcamp-code/blob/master/chapter-03-churn-prediction/03-churn.ipynb

Updated Link: https://github.com/DataTalksClub/machine-learning-zoomcamp/blob/master/03-classification/notebook.ipynb

Change made in the following pages:

- 02-data-preparation.md
- 03-validation.md
- 04-eda.md
- 05-risk.md
- 06-mutual-info.md
- 07-correlation.md
- 08-ohe.md
- 09-logistic-regression.md
- 10-training-log-reg.md
- 11-log-reg-interpretation.md
