### PR TITLE
Fix: update docker url in the 2025 serverless homework

### DIFF
--- a/cohorts/2025/09-serverless/homework.md
+++ b/cohorts/2025/09-serverless/homework.md
@@ -124,7 +124,7 @@ COPY hair_classifier_empty.onnx .
 
 Note that it uses Python 3.13.
 
-The docker image is published to [`agrigorev/model-2024-hairstyle:v3`](https://hub.docker.com/r/agrigorev/model-2024-hairstyle/tags).
+The docker image is published to [`agrigorev/model-2025-hairstyle:v1`](https://hub.docker.com/r/agrigorev/model-2025-hairstyle).
 
 A few notes:
 


### PR DESCRIPTION
Updated Docker image URL of 2025 cohort module9-serverless homework