### PR TITLE
docs: fix pandas column access with spaces

### DIFF
--- a/01-intro/notebooks/09-pandas.ipynb
+++ b/01-intro/notebooks/09-pandas.ipynb
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 1,
    "id": "b1a23fb2",
    "metadata": {},
    "outputs": [],
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 2,
    "id": "114c8ddb",
    "metadata": {},
    "outputs": [],
@@ -66,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 3,
    "id": "c25c6c9d",
    "metadata": {},
    "outputs": [],
@@ -76,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 4,
    "id": "abe4d2e4",
    "metadata": {},
    "outputs": [
@@ -187,7 +187,7 @@
        "4        Pickup  32340  "
       ]
      },
-     "execution_count": 9,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -198,7 +198,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 5,
    "id": "f104d442",
    "metadata": {},
    "outputs": [],
@@ -259,7 +259,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "id": "2d89579e",
    "metadata": {},
    "outputs": [
@@ -370,7 +370,7 @@
        "4        Pickup  32340  "
       ]
      },
-     "execution_count": 12,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -382,7 +382,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 7,
    "id": "097f69d9",
    "metadata": {},
    "outputs": [
@@ -454,7 +454,7 @@
        "1         Sedan  27150  "
       ]
      },
-     "execution_count": 14,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -481,26 +481,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "7299a212",
    "metadata": {},
    "outputs": [
     {
-     "ename": "SyntaxError",
-     "evalue": "invalid syntax (1897567212.py, line 1)",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;36m  File \u001b[0;32m\"/tmp/ipykernel_580/1897567212.py\"\u001b[0;36m, line \u001b[0;32m1\u001b[0m\n\u001b[0;31m    df.Engine HP\u001b[0m\n\u001b[0m              ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m invalid syntax\n"
-     ]
+     "data": {
+      "text/plain": [
+       "\"to access columns with spaces in their names, wrap the column name in quotes and square brackets['']\""
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "df.Engine HP"
+    "# df.Engine HP --> this will throw a syntax error\n",
+    "\"to access columns with spaces in their names, wrap the column name in quotes and square brackets['replace with your column name']\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 9,
    "id": "54898f9d",
    "metadata": {},
    "outputs": [
@@ -515,7 +518,7 @@
        "Name: Engine HP, dtype: float64"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -526,7 +529,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 10,
    "id": "acc40580",
    "metadata": {},
    "outputs": [
@@ -600,7 +603,7 @@
        "4   Nissan  Frontier  32340"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -611,7 +614,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 11,
    "id": "9c699894",
    "metadata": {},
    "outputs": [],
@@ -621,7 +624,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 12,
    "id": "70ec4449",
    "metadata": {},
    "outputs": [],
@@ -631,7 +634,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 13,
    "id": "ff30947e",
    "metadata": {},
    "outputs": [
@@ -748,7 +751,7 @@
        "4        Pickup  32340  50  "
       ]
      },
-     "execution_count": 27,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -759,7 +762,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 14,
    "id": "064e3e7c",
    "metadata": {},
    "outputs": [],
@@ -769,7 +772,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 15,
    "id": "5206c3ba",
    "metadata": {},
    "outputs": [
@@ -880,7 +883,7 @@
        "4        Pickup  32340  "
       ]
      },
-     "execution_count": 29,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -899,7 +902,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 16,
    "id": "69e9bfbd",
    "metadata": {},
    "outputs": [
@@ -909,7 +912,7 @@
        "RangeIndex(start=0, stop=5, step=1)"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -920,7 +923,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 17,
    "id": "d7e06c93",
    "metadata": {},
    "outputs": [
@@ -930,7 +933,7 @@
        "RangeIndex(start=0, stop=5, step=1)"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -941,7 +944,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 18,
    "id": "14213eb4",
    "metadata": {},
    "outputs": [],
@@ -951,7 +954,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 19,
    "id": "d9074134",
    "metadata": {},
    "outputs": [
@@ -1062,7 +1065,7 @@
        "e        Pickup  32340  "
       ]
      },
-     "execution_count": 38,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1073,7 +1076,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 20,
    "id": "a1c57024",
    "metadata": {},
    "outputs": [
@@ -1158,7 +1161,7 @@
        "e        Pickup  32340  "
       ]
      },
-     "execution_count": 42,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1169,7 +1172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 21,
    "id": "764c2aad",
    "metadata": {},
    "outputs": [],
@@ -1179,7 +1182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 22,
    "id": "f338e70b",
    "metadata": {},
    "outputs": [
@@ -1290,7 +1293,7 @@
        "4        Pickup  32340  "
       ]
      },
-     "execution_count": 48,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1325,7 +1328,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 23,
    "id": "318183a8",
    "metadata": {},
    "outputs": [
@@ -1340,7 +1343,7 @@
        "Name: Engine HP, dtype: float64"
       ]
      },
-     "execution_count": 51,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1351,7 +1354,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 24,
    "id": "ae5d726d",
    "metadata": {},
    "outputs": [
@@ -1366,7 +1369,7 @@
        "Name: Year, dtype: bool"
       ]
      },
-     "execution_count": 53,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1385,7 +1388,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 25,
    "id": "73699361",
    "metadata": {},
    "outputs": [
@@ -1457,7 +1460,7 @@
        "4        Pickup  32340  "
       ]
      },
-     "execution_count": 55,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1470,7 +1473,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 26,
    "id": "0f29ed0f",
    "metadata": {},
    "outputs": [
@@ -1529,7 +1532,7 @@
        "4        Pickup  32340  "
       ]
      },
-     "execution_count": 56,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1550,7 +1553,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 27,
    "id": "7deaf57a",
    "metadata": {},
    "outputs": [
@@ -1560,7 +1563,7 @@
        "'machine_learning_zoomcamp'"
       ]
      },
-     "execution_count": 68,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1571,7 +1574,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 28,
    "id": "9ffa16ea",
    "metadata": {},
    "outputs": [
@@ -1586,7 +1589,7 @@
        "Name: Vehicle_Style, dtype: object"
       ]
      },
-     "execution_count": 67,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1597,7 +1600,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 29,
    "id": "835c3a40",
    "metadata": {},
    "outputs": [],
@@ -1607,7 +1610,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 30,
    "id": "5ee197dc",
    "metadata": {},
    "outputs": [
@@ -1718,7 +1721,7 @@
        "4        pickup  32340  "
       ]
      },
-     "execution_count": 74,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1737,7 +1740,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 31,
    "id": "0e6bb68a",
    "metadata": {},
    "outputs": [
@@ -1841,7 +1844,7 @@
        "max    2017.00     261.00              6.00  54990.00"
       ]
      },
-     "execution_count": 81,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1852,7 +1855,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": 32,
    "id": "ca689f7b",
    "metadata": {},
    "outputs": [
@@ -1870,7 +1873,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 85,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1889,7 +1892,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": 33,
    "id": "05000331",
    "metadata": {},
    "outputs": [
@@ -1907,7 +1910,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 87,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1942,7 +1945,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": 34,
    "id": "6310552b",
    "metadata": {},
    "outputs": [
@@ -1955,7 +1958,7 @@
        "Name: MSRP, dtype: int64"
       ]
      },
-     "execution_count": 90,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1974,7 +1977,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 93,
+   "execution_count": 35,
    "id": "749f764c",
    "metadata": {},
    "outputs": [
@@ -1984,7 +1987,7 @@
        "array([ 2000, 27150, 54990, 34450, 32340])"
       ]
      },
-     "execution_count": 93,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1995,7 +1998,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": 36,
    "id": "1ff56c15",
    "metadata": {},
    "outputs": [
@@ -2044,7 +2047,7 @@
        "  'MSRP': 32340}]"
       ]
      },
-     "execution_count": 95,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2064,7 +2067,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "myenv",
    "language": "python",
    "name": "python3"
   },
@@ -2078,7 +2081,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## What does this PR do?
Improves the comment on cell 46 about accessing DataFrame columns with spaces in their names, making it clearer for beginners.

## Changes Made
- Commented out line of code and added explanation: `# df.Engine HP --> this will throw a syntax error`
- Provided clearer syntax: `# to access columns with spaces in their names, wrap the column name in quotes and square brackets['replace your column name']`
- Made instructions more explicit and beginner-friendly

## Why is this important?
- Prevents syntax errors for learners
- Provides clear, actionable guidance
- Shows both wrong and right approaches
- Improves educational quality for pandas beginners

## Checklist
- [x] Self-reviewed the change
- [x] Instructions are clear and correct
- [x] Helps prevent common pandas mistakes
- [x] No code functionality changed