### PR TITLE
Unify README to shared zoomcamp structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,10 @@
-<h1 align="center">
-    <strong>Machine Learning Zoomcamp: A Free 4-Month Course on ML Engineering</strong>
-</h1>
-
 <p align="center">
 <img src="images/ml-zoomcamp.png" alt="Machine Learning Zoomcamp" width="500" />
 </p>
 
-<p align="center">
-<a href="https://courses.datatalks.club/">Course platform with deadlines and submission forms for homework assignments and projects</a> •
-<a href="https://datatalks.club/slack.html"> Course Channel on Slack (#course-ml-zoomcamp) </a> •
-<a href="https://t.me/mlzoomcamp">Telegram Announcements</a> •
-<a href="https://www.youtube.com/playlist?list=PL3MmuxUbc_hIhxl5Ji8t4O6lPAOpHaCLR">Course Playlist</a> •
-<a href="https://datatalks.club/faq/machine-learning-zoomcamp.html">FAQ</a> •
-<a href="https://ctt.ac/XZ6b9">Tweet about the Course</a>
-</p>
-
-
+<h1 align="center">
+    Machine Learning Zoomcamp: A Free 4-Month Course on ML Engineering
+</h1>
 
 <p align="center">
 Learn machine learning engineering end-to-end, from core models to deploying real applications.
@@ -29,38 +18,60 @@ Build regression and classification models in Python, work with key algorithms l
 <a href="https://airtable.com/shryxwLd0COOEaqXo"><img src="https://user-images.githubusercontent.com/875246/185755203-17945fd1-6b64-46f2-8377-1011dcb1a444.png" height="50" /></a>
 </p>
 
-## Table of Contents
-- [What This Course Is About](#about-ml-zoomcamp)
-- [Prerequisites](#prerequisites)
-- [How to Join](#how-to-join)
-- [Syllabus](#syllabus)
-- [Community & Getting Help](#community--getting-help)
-- [Certificates](#certificates)
-- [Sponsors](#sponsors)
-- [About DataTalks.Club](#about-datatalksclub)
+<p align="center">
+<a href="https://datatalks.club/slack.html">Join Slack</a> •
+<a href="https://app.slack.com/client/T01ATQK62F8/C0288NJ5XSA">#course-ml-zoomcamp Channel</a> •
+<a href="https://t.me/mlzoomcamp">Telegram Announcements</a> •
+<a href="https://www.youtube.com/playlist?list=PL3MmuxUbc_hIhxl5Ji8t4O6lPAOpHaCLR">Course Playlist</a> •
+<a href="https://datatalks.club/faq/machine-learning-zoomcamp.html">FAQ</a> •
+<a href="https://ctt.ac/XZ6b9">Tweet about the Course</a>
+</p>
 
-## About ML Zoomcamp
-Machine Learning Zoomcamp teaches you the complete machine learning engineering, covering the entire pipeline: from building models with Python to deploying them in production environments.
+<p align="center">
+<a href="https://github.com/DataTalksClub/machine-learning-zoomcamp/pulls"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=for-the-badge" /></a>
+<a href="https://datatalks.club/slack.html"><img src="https://img.shields.io/badge/Slack-Join%20Community-4A154B?style=for-the-badge&logo=slack" /></a>
+</p>
+
+## Quick Links
+
+| Resource | Link |
+|----------|------|
+| Course materials | [GitHub repository](https://github.com/DataTalksClub/machine-learning-zoomcamp) |
+| Video lectures | [YouTube playlist](https://www.youtube.com/playlist?list=PL3MmuxUbc_hIhxl5Ji8t4O6lPAOpHaCLR) |
+| Documentation | [Zoomcamp Logistics](https://datatalks.club/docs/courses/zoomcamp-logistics/) · [ML Zoomcamp](https://datatalks.club/docs/courses/ml-zoomcamp/) |
+| Course platform (deadlines, homework) | [courses.datatalks.club](https://courses.datatalks.club/) |
+| Slack channel | [#course-ml-zoomcamp](https://app.slack.com/client/T01ATQK62F8/C0288NJ5XSA) |
+| Announcements | [Telegram](https://t.me/mlzoomcamp) |
+| FAQ | [FAQ document](https://datatalks.club/faq/machine-learning-zoomcamp.html) |
+
+## About the Course
+
+Machine Learning Zoomcamp teaches complete machine learning engineering, covering the entire pipeline: from building models with Python to deploying them in production environments.
 
 <p align="center">
 <img src="https://github.com/DataTalksClub/datatalksclub.github.io/blob/main/images/posts/2024-04-11-guide-to-free-online-courses-at-datatalks-club/ml_zoomcamp_overview_horizontal_2025.png" alt="ML Zoomcamp course overview showing progression from ML algorithms (Python, NumPy, Pandas, Scikit-learn) to deployment (Docker, FastAPI, Kubernetes)" title="ML Zoomcamp course overview: ML algorithms to deployment" width="500" />
 </p>
 
-You’ll master the key ML algorithms like linear regression, logistic regression, decision trees, and deep learning with TensorFlow and PyTorch, then learn to containerize with Docker, build APIs with FastAPI, and scale with Kubernetes and AWS Lambda.
+You'll master the key ML algorithms like linear regression, logistic regression, decision trees, and deep learning with TensorFlow and PyTorch, then learn to containerize with Docker, build APIs with FastAPI, and scale with Kubernetes and AWS Lambda.
+
+## Who Should Join
+
+This course is for software engineers, data analysts, and anyone with programming experience who wants to become a machine learning engineer. You don't need any prior machine learning experience; the course starts from the basics.
 
 ## Prerequisites
 
-**You'll need:**
+You'll need:
+
 - Prior programming experience (at least 1+ year)
 - Comfort with command line basics
 
 You don't need any prior experience with machine learning. We'll start from the basics.
 
-**Technical setup**: For machine learning modules, you only need a laptop with an internet connection. For deep learning sections, we'll use cloud resources for more intensive computations.
+Technical setup: for the machine learning modules, you only need a laptop with an internet connection. For the deep learning sections, we'll use cloud resources for more intensive computations.
 
-## How to Join
+## How to Take the Course
 
-You can join ML Zoomcamp either by **following a live cohort** or **learning at your own pace**.
+You can join ML Zoomcamp either by following a live cohort or learning at your own pace.
 
 All materials are freely available in this repository. Each module has its own folder (e.g., `01-intro`, `03-classification`), and cohort-specific homework and deadlines are in the `cohorts` directory. Lectures are pre-recorded and available in this [YouTube playlist](https://www.youtube.com/playlist?list=PL3MmuxUbc_hIhxl5Ji8t4O6lPAOpHaCLR).
 
@@ -81,7 +92,22 @@ flowchart TD
     D --> D3["No certificate"]
 ```
 
-### Option 1: Self-Paced Learning
+### Live Cohort
+
+2026 Cohort: starts in September. Register here: [Fill in this form](https://airtable.com/shryxwLd0COOEaqXo)
+
+Runs once per year (September–December). Includes:
+
+- Updated homework
+- Automatic homework scoring and a leaderboard
+- Project peer review
+- Eligibility for a certificate after meeting all requirements
+
+Even if you join after the official start date, you can still follow along, but note that some homework forms may already be closed. All active deadlines are listed on the [course platform](https://courses.datatalks.club).
+
+To earn a [certificate](#certificate), you'll need enough time to complete two [projects](#projects) and the required peer reviews. Details are in the Projects and Certificate sections.
+
+### Self-Paced
 
 Start anytime. You get full access to materials and community support on Slack.
 
@@ -89,89 +115,77 @@ Complete homework assignments: homework and solutions are available on the [cour
 
 > Under self-paced learning, homework isn't scored, your project isn't peer-reviewed, and you can't earn a certificate.
 
-### Option 2: Live Cohort
-
-> **2026 Cohort:** Starts in September. Register here: [Fill in this form](https://airtable.com/shryxwLd0COOEaqXo)
-
-Runs once per year (September–December).
-
-Includes:
-- Updated homework
-- Automatic homework scoring and a leaderboard
-- Project peer review
-- Eligibility for a certificate after meeting all requirements
-
-Even if you join after the official start date, you can still follow along — but note that some homework forms may already be closed. All active deadlines are listed on the [course platform](https://courses.datatalks.club).
-
-> To earn a [certificate](#certificate), you'll need enough time to complete two [projects](#projects) and the required peer reviews. Details are in the Projects and Certificate sections.
-
 ### Comparison
 
 We summarized the key differences between the two joining options in this table:
+
 | Feature | Self-Paced | Live Cohort |
 |---------|------------|-------------|
-| **Timing** | Learn at your own pace, start anytime | Fixed 4-month schedule (September–December each year) |
-| **Course Materials** | Full access to GitHub repository and YouTube lectures | Full access to GitHub repository and YouTube lectures |
-| **Community** | Access to Slack community (`#course-ml-zoomcamp`) | Access to Slack community (`#course-ml-zoomcamp`) |
-| **Homework** | Available but not scored | Scored automatically, appears on leaderboard |
-| **Projects** | Build on your own, no evaluation | Submit 2 projects (midterm + capstone OR two capstones) with peer review |
-| **Certificate** | Not available | Available after completing projects and peer reviews |
-| **Structure** | Flexible, no deadlines | Weekly rhythm with deadlines and peer accountability |
+| Timing | Learn at your own pace, start anytime | Fixed 4-month schedule (September–December each year) |
+| Course Materials | Full access to GitHub repository and YouTube lectures | Full access to GitHub repository and YouTube lectures |
+| Community | Access to Slack community (`#course-ml-zoomcamp`) | Access to Slack community (`#course-ml-zoomcamp`) |
+| Homework | Available but not scored | Scored automatically, appears on leaderboard |
+| Projects | Build on your own, no evaluation | Submit 2 projects (midterm + capstone OR two capstones) with peer review |
+| Certificate | Not available | Available after completing projects and peer reviews |
+| Structure | Flexible, no deadlines | Weekly rhythm with deadlines and peer accountability |
 
 <p align="center">
-  <strong>Ready to start? <a href="https://airtable.com/shryxwLd0COOEaqXo">Join the 2026 cohort</a> or <a href="01-intro/">start with Module 1</a></strong>
+Ready to start? <a href="https://airtable.com/shryxwLd0COOEaqXo">Join the 2026 cohort</a> or <a href="01-intro/">start with Module 1</a>
 </p>
 
 ## Syllabus
 
 | Module | Description | Topics |
 |--------|-------------|--------|
-| **[Module 1: Introduction to Machine Learning](01-intro/)** | Learn the fundamentals: what ML is, when to use it, and how to approach ML problems using the CRISP-DM framework. | • ML vs rule-based systems<br>• Supervised learning basics<br>• CRISP-DM methodology<br>• Model selection concepts<br>• Environment setup |
-| **[Module 2: Machine Learning for Regression](02-regression/)** | Build a car price prediction model while learning linear regression, feature engineering, and regularization. | • Linear regression (from scratch and with scikit-learn)<br>• Exploratory data analysis<br>• Feature engineering<br>• Regularization techniques<br>• Model validation |
-| **[Module 3: Machine Learning for Classification](03-classification/)** | Create a customer churn prediction system using logistic regression and learn about feature selection. | • Logistic regression<br>• Feature importance and selection<br>• Categorical variable encoding<br>• Model interpretation |
-| **[Module 4: Evaluation Metrics for Classification](04-evaluation/)** | Learn how to properly evaluate classification models and handle imbalanced datasets. | • Accuracy, precision, recall, F1-score<br>• ROC curves and AUC<br>• Cross-validation<br>• Confusion matrices<br>• Class imbalance handling |
-| **[Module 5: Deploying Machine Learning Models](05-deployment/)** | Turn your models into web services and deploy them with Docker and cloud platforms. | • Model serialization with Pickle<br>• FastAPI web services<br>• Docker containerization<br>• Cloud deployment |
-| **[Module 6: Decision Trees & Ensemble Learning](06-trees/)** | Learn tree-based models and ensemble methods for better predictions. | • Decision trees<br>• Random Forest<br>• Gradient boosting (XGBoost)<br>• Hyperparameter tuning<br>• Feature importance |
-| **[Midterm Project](projects/)** |  |  |
-| **[Module 8: Neural Networks & Deep Learning](08-deep-learning/)** | Introduction to neural networks using TensorFlow and Keras, including CNNs and transfer learning. | • Neural network fundamentals<br>• PyTorch<br>• TensorFlow & Keras<br>• Convolutional Neural Networks<br>• Transfer learning<br>• Model optimization |
-| **[Module 9: Serverless Deep Learning](09-serverless/)** | Deploy deep learning models using serverless technologies like AWS Lambda. | • Serverless concepts<br>• Deploying Scikit-Learn models with AWS Lambda<br>• Deploying TensorFlow and PyTorch models with AWS Lambda<br>• API Gateway |
-| **[Module 10: Kubernetes & TensorFlow Serving](10-kubernetes/)** | Learn to serve ML models at scale using Kubernetes and TensorFlow Serving. | • Kubernetes basics<br>• TensorFlow Serving<br>• Model deployment and scaling<br>• Load balancing |
-| **[Capstone project 1](projects/)** |  |  |
-| **[Capstone project 2](projects/)** |  |  |
+| [Module 1: Introduction to Machine Learning](01-intro/) | Learn the fundamentals: what ML is, when to use it, and how to approach ML problems using the CRISP-DM framework. | • ML vs rule-based systems<br>• Supervised learning basics<br>• CRISP-DM methodology<br>• Model selection concepts<br>• Environment setup |
+| [Module 2: Machine Learning for Regression](02-regression/) | Build a car price prediction model while learning linear regression, feature engineering, and regularization. | • Linear regression (from scratch and with scikit-learn)<br>• Exploratory data analysis<br>• Feature engineering<br>• Regularization techniques<br>• Model validation |
+| [Module 3: Machine Learning for Classification](03-classification/) | Create a customer churn prediction system using logistic regression and learn about feature selection. | • Logistic regression<br>• Feature importance and selection<br>• Categorical variable encoding<br>• Model interpretation |
+| [Module 4: Evaluation Metrics for Classification](04-evaluation/) | Learn how to properly evaluate classification models and handle imbalanced datasets. | • Accuracy, precision, recall, F1-score<br>• ROC curves and AUC<br>• Cross-validation<br>• Confusion matrices<br>• Class imbalance handling |
+| [Module 5: Deploying Machine Learning Models](05-deployment/) | Turn your models into web services and deploy them with Docker and cloud platforms. | • Model serialization with Pickle<br>• FastAPI web services<br>• Docker containerization<br>• Cloud deployment |
+| [Module 6: Decision Trees & Ensemble Learning](06-trees/) | Learn tree-based models and ensemble methods for better predictions. | • Decision trees<br>• Random Forest<br>• Gradient boosting (XGBoost)<br>• Hyperparameter tuning<br>• Feature importance |
+| [Midterm Project](projects/) |  |  |
+| [Module 8: Neural Networks & Deep Learning](08-deep-learning/) | Introduction to neural networks using TensorFlow and Keras, including CNNs and transfer learning. | • Neural network fundamentals<br>• PyTorch<br>• TensorFlow & Keras<br>• Convolutional Neural Networks<br>• Transfer learning<br>• Model optimization |
+| [Module 9: Serverless Deep Learning](09-serverless/) | Deploy deep learning models using serverless technologies like AWS Lambda. | • Serverless concepts<br>• Deploying Scikit-Learn models with AWS Lambda<br>• Deploying TensorFlow and PyTorch models with AWS Lambda<br>• API Gateway |
+| [Module 10: Kubernetes & TensorFlow Serving](10-kubernetes/) | Learn to serve ML models at scale using Kubernetes and TensorFlow Serving. | • Kubernetes basics<br>• TensorFlow Serving<br>• Model deployment and scaling<br>• Load balancing |
+| [Capstone project 1](projects/) |  |  |
+| [Capstone project 2](projects/) |  |  |
 
-### Projects
+## Projects
 
 Choose a problem that interests you, find a suitable dataset, develop your model, and deploy it as a web service.
 
 There will be 3 projects:
+
 1. [Midterm Project](projects/) after [Module 6: Decision Trees & Ensemble Learning](06-trees/)
 2. [Capstone project 1](projects/) at the end of the course, after [Module 10: Kubernetes & TensorFlow Serving](10-kubernetes/)
 3. [Capstone project 2](projects/) at the end of the course, after [Module 10: Kubernetes & TensorFlow Serving](10-kubernetes/)
 
 These projects allow you to apply everything you've learned and make a great addition to your GitHub profile and portfolio.
 
-#### Project Examples from Past Cohorts
+### Project Examples from Past Cohorts
 
 <p align="center">
-<img src="https://github.com/DataTalksClub/datatalksclub.github.io/blob/main/images/posts/2025-08-11-tab-1-how-to-build-blood-cell-classifier-for-cancer-prediction-case-study-from-ml-zoomcamp/image9.png" alt="Machine Learning Zoomcamp certificate of completion awarded after successfully completing projects and peer reviews" title="ML Zoomcamp Certificate of Completion" width="500", align=center />
+<img src="https://github.com/DataTalksClub/datatalksclub.github.io/blob/main/images/posts/2025-08-11-tab-1-how-to-build-blood-cell-classifier-for-cancer-prediction-case-study-from-ml-zoomcamp/image9.png" alt="A local deployment architecture using Kubernetes with Kind from one of the students' projects" title="Student project: local Kubernetes deployment with Kind" width="500" align="center" />
 <p align="center"> <i> A local deployment architecture using Kubernetes with Kind from one of the students' projects </i> </p>
 </p>
 
 Some of the course projects from past cohorts:
+
 - [Blood cell classifier for cancer prediction](https://datatalks.club/blog/how-to-build-blood-cell-classifier-for-cancer-prediction-case-study-from-ml-zoomcamp.html): an end-to-end tool that segments and classifies blood cells from microscope images to assist in detecting signs of acute lymphoblastic leukemia (ALL)
 - [Waste classifier](https://datatalks.club/blog/how-to-build-waste-classifier-case-study-from-ml-zoomcamp.html): an Xception-based image classifier on ~15,000 waste images, reaching 93.3% test accuracy, and serving predictions via a Flask API packaged in Docker
 
 ## Certificate
+
 <p align="center">
-<img src="https://github.com/DataTalksClub/datatalksclub.github.io/blob/main/images/posts/2023-08-17-machine-learning-zoomcamp/ml-zoomcamp-certificate.jpg" alt="Machine Learning Zoomcamp certificate of completion awarded after successfully completing projects and peer reviews" title="ML Zoomcamp Certificate of Completion" width="500", align=center />
+<img src="https://github.com/DataTalksClub/datatalksclub.github.io/blob/main/images/posts/2023-08-17-machine-learning-zoomcamp/ml-zoomcamp-certificate.jpg" alt="Machine Learning Zoomcamp certificate of completion awarded after successfully completing projects and peer reviews" title="ML Zoomcamp Certificate of Completion" width="500" align="center" />
 <p align="center"> <i> Machine Learning Zoomcamp certificate awarded upon successful completion </i> </p>
 </p>
 
 To receive a certificate, you'll need to complete and submit two projects:
 
-1. **Complete two projects**: Submit either a midterm project and a capstone project, OR two capstone projects
-2. **Submit on time**: Meet the project submission deadlines to qualify for certification
-3. **Peer review**: Evaluate and provide feedback on 3 fellow students' projects during the peer review process
+1. Complete two projects: submit either a midterm project and a capstone project, OR two capstone projects
+2. Submit on time: meet the project submission deadlines to qualify for certification
+3. Peer review: evaluate and provide feedback on 3 fellow students' projects during the peer review process
 
 ## Testimonials
 
@@ -179,7 +193,7 @@ To receive a certificate, you'll need to complete and submit two projects:
 >
 > - [Alexander Daniel Rios](https://www.linkedin.com/in/alexander-daniel-rios) ([Source](https://www.linkedin.com/posts/alexander-daniel-rios_mlzoomcamp-activity-7295527609239584768-TWHh))
 
-> Machine Learning Zoomcamp has been an incredible journey, thanks to the expert guidance of Alexey Grigorev. Hugely grateful to Alexey, Timur, and the entire DataTalksClub team for this course, and to my cohort batchmates for the invaluable support that enriched my learning experience. I’m thankful for this programme, which provided challenging coursework that is taught in a very structured and lucid way. The timely assignments & hands-on projects instill the sense of timely delivery, besides equipping us with practical acumen to solve real-life problems.
+> Machine Learning Zoomcamp has been an incredible journey, thanks to the expert guidance of Alexey Grigorev. Hugely grateful to Alexey, Timur, and the entire DataTalksClub team for this course, and to my cohort batchmates for the invaluable support that enriched my learning experience. I'm thankful for this programme, which provided challenging coursework that is taught in a very structured and lucid way. The timely assignments & hands-on projects instill the sense of timely delivery, besides equipping us with practical acumen to solve real-life problems.
 >
 > - [Siddhartha Gogoi](https://www.linkedin.com/in/siddhartha-gogoi) ([Source](https://www.linkedin.com/posts/activity-7299906113997524994-R-oD?utm_source=share&utm_medium=member_desktop&rcm=ACoAADJu9vMBW6iyIYswCQnN6t8UJLkXH2tQPi4))
 
@@ -191,7 +205,7 @@ To receive a certificate, you'll need to complete and submit two projects:
 >
 > - [Abdiaziz Mohamed](https://www.linkedin.com/in/abdiaziz-mohamed) ([Source 1](https://www.linkedin.com/posts/abdiaziz-mohamed_machinelearning-deployment-docker-activity-7257086439333523456-CyK4), [Source 2](https://www.linkedin.com/posts/abdiaziz-mohamed_machinelearningzoomcamp-machinelearning-kubernetes-activity-7277039208072904704-OAiY?utm_source=share&utm_medium=member_desktop&rcm=ACoAADJu9vMBW6iyIYswCQnN6t8UJLkXH2tQPi4))
 
-> A huge thank you to Alexey Grigoriev for creating such an amazing course—and making it free! It’s truly inspiring.
+> A huge thank you to Alexey Grigoriev for creating such an amazing course—and making it free! It's truly inspiring.
 >
 > - [Guilherme Pereira](https://www.linkedin.com/in/guilherme-torres-pereira) ([Source](https://www.linkedin.com/posts/guilherme-torres-pereira_alexeygrigoriev-mlzoomcamp-machinelearning-activity-7396336012018356224-sK27))
 
@@ -199,29 +213,23 @@ To receive a certificate, you'll need to complete and submit two projects:
 >
 > - [Rajendra Rawale](https://www.linkedin.com/in/rajendra1x) ([Source](https://www.linkedin.com/posts/rajendra1x_machinelearning-mlzoomcamp-datatalksclub-activity-7378450260999852032-V5Z1))
 
-<p align="center">
-  <strong>Ready to start? <a href="https://airtable.com/shryxwLd0COOEaqXo">Join the 2025 cohort</a> or <a href="01-intro/">start with Module 1</a></strong>
-</p>
+## Community & Support
 
-## Community & Getting Help
+### Getting Help on Slack
 
-### Where to Get Help
-- **Slack**: [`#course-ml-zoomcamp`](https://app.slack.com/client/T01ATQK62F8/C0288NJ5XSA) channel
-- **FAQ**: [Common questions and answers](https://datatalks.club/faq/machine-learning-zoomcamp.html)
-- **Study Groups**: Connect with other learners
+Join the [#course-ml-zoomcamp](https://app.slack.com/client/T01ATQK62F8/C0288NJ5XSA) channel on [DataTalks.Club Slack](https://datatalks.club/slack.html) for discussions, troubleshooting, and networking.
 
-### Community Guidelines
-- Check the [FAQ](https://datatalks.club/faq/machine-learning-zoomcamp.html) first
-- Follow our [question guidelines](https://datatalks.club/docs/courses/zoomcamp-logistics/asking-questions/)
-- Be helpful and respectful
-- Share your learning journey
+To keep discussions organized:
+
+- Check the [FAQ](https://datatalks.club/faq/machine-learning-zoomcamp.html) first.
+- Follow our [question guidelines](https://datatalks.club/docs/courses/zoomcamp-logistics/asking-questions/) when posting questions.
+- Review the [community guidelines](https://datatalks.club/slack/guidelines.html).
 
 ### Learning in Public
-We encourage sharing your progress! Write blog posts, create videos, post on social media with #mlzoomcamp. It helps you learn better and builds your professional network.
 
-**Bonus**: You can earn extra points for sharing your learning experience publicly.
+We encourage sharing your progress! Write blog posts, create videos, and post on social media with #mlzoomcamp. It helps you learn better and builds your professional network. You can also earn extra points for sharing your learning experience publicly.
 
-Learn more: [Learning in Public](learning-in-public.md)
+Learn more: [Learning in Public](learning-in-public.md).
 
 ## Sponsors
 
@@ -249,3 +257,5 @@ Interested in sponsoring? Contact [alexey@datatalks.club](mailto:alexey@datatalk
 </p>
 
 All the activity at DataTalks.Club mainly happens on [Slack](https://datatalks.club/slack.html). We post updates there and discuss different aspects of data, career questions, and more.
+
+At DataTalks.Club, we organize online events, community activities, and free courses. You can learn more about what we do at [DataTalks.Club docs](https://datatalks.club/docs/general/).

--- a/README.md
+++ b/README.md
@@ -71,84 +71,130 @@ Technical setup: for the machine learning modules, you only need a laptop with a
 
 ## How to Take the Course
 
-You can join ML Zoomcamp either by following a live cohort or learning at your own pace.
+There are two ways to follow the course: live and self-paced.
 
-All materials are freely available in this repository. Each module has its own folder (e.g., `01-intro`, `03-classification`), and cohort-specific homework and deadlines are in the `cohorts` directory. Lectures are pre-recorded and available in this [YouTube playlist](https://www.youtube.com/playlist?list=PL3MmuxUbc_hIhxl5Ji8t4O6lPAOpHaCLR).
+| | Live Cohort | Self-Paced |
+|-|-|-|
+| Start | September 2026 | Anytime |
+| Lectures | Pre-recorded | Pre-recorded |
+| Homework | Graded | Available but not scored |
+| Leaderboard | ✅ Yes | ❌ No |
+| Peer Review | ✅ Yes | ❌ No |
+| Certificate | ✅ Yes | ❌ No |
+| Cost | Free | Free |
+| Register | [Sign up here](https://airtable.com/shryxwLd0COOEaqXo) | Just start learning! |
 
-```mermaid
-flowchart TD
-    A["Want to learn Machine Learning Zoomcamp"] --> B{"Do you want<br/>deadlines & a certificate?"}
+> [!IMPORTANT]
+> "Live cohort" does not mean live classes. All lectures are pre-recorded. "Live" means working alongside others with deadlines, scored homework, a leaderboard, peer review, and a certificate at the end. The live cohort runs once per year (September to December).
 
-    B -->|Yes| C["Join Live Cohort"]
-    B -->|No / Not sure| D["Self-Paced Learning"]
+To earn a certificate, you'll complete two [projects](#projects) (midterm + capstone, or two capstones) and the required peer reviews during a live cohort.
 
-    C --> C1["Fixed schedule (Sept–Dec)"]
-    C --> C2["Scored homework + leaderboard"]
-    C --> C3["2 projects + peer review"]
-    C --> C4["Eligible for certificate"]
+Self-paced steps:
 
-    D --> D1["Start anytime, go at your own pace"]
-    D --> D2["Unscored homework & optional projects"]
-    D --> D3["No certificate"]
-```
-
-### Live Cohort
-
-2026 Cohort: starts in September. Register here: [Fill in this form](https://airtable.com/shryxwLd0COOEaqXo)
-
-Runs once per year (September–December). Includes:
-
-- Updated homework
-- Automatic homework scoring and a leaderboard
-- Project peer review
-- Eligibility for a certificate after meeting all requirements
-
-Even if you join after the official start date, you can still follow along, but note that some homework forms may already be closed. All active deadlines are listed on the [course platform](https://courses.datatalks.club).
-
-To earn a [certificate](#certificate), you'll need enough time to complete two [projects](#projects) and the required peer reviews. Details are in the Projects and Certificate sections.
-
-### Self-Paced
-
-Start anytime. You get full access to materials and community support on Slack.
-
-Complete homework assignments: homework and solutions are available on the [course platform](https://courses.datatalks.club). Build a project for your portfolio.
-
-> Under self-paced learning, homework isn't scored, your project isn't peer-reviewed, and you can't earn a certificate.
-
-### Comparison
-
-We summarized the key differences between the two joining options in this table:
-
-| Feature | Self-Paced | Live Cohort |
-|---------|------------|-------------|
-| Timing | Learn at your own pace, start anytime | Fixed 4-month schedule (September–December each year) |
-| Course Materials | Full access to GitHub repository and YouTube lectures | Full access to GitHub repository and YouTube lectures |
-| Community | Access to Slack community (`#course-ml-zoomcamp`) | Access to Slack community (`#course-ml-zoomcamp`) |
-| Homework | Available but not scored | Scored automatically, appears on leaderboard |
-| Projects | Build on your own, no evaluation | Submit 2 projects (midterm + capstone OR two capstones) with peer review |
-| Certificate | Not available | Available after completing projects and peer reviews |
-| Structure | Flexible, no deadlines | Weekly rhythm with deadlines and peer accountability |
-
-<p align="center">
-Ready to start? <a href="https://airtable.com/shryxwLd0COOEaqXo">Join the 2026 cohort</a> or <a href="01-intro/">start with Module 1</a>
-</p>
+1. Follow the materials on [GitHub](https://github.com/DataTalksClub/machine-learning-zoomcamp)
+2. Ask questions and share progress in [Slack](https://datatalks.club/slack.html)
+3. Do the homework (self-checked) and build a project for your portfolio
 
 ## Syllabus
 
-| Module | Description | Topics |
-|--------|-------------|--------|
-| [Module 1: Introduction to Machine Learning](01-intro/) | Learn the fundamentals: what ML is, when to use it, and how to approach ML problems using the CRISP-DM framework. | • ML vs rule-based systems<br>• Supervised learning basics<br>• CRISP-DM methodology<br>• Model selection concepts<br>• Environment setup |
-| [Module 2: Machine Learning for Regression](02-regression/) | Build a car price prediction model while learning linear regression, feature engineering, and regularization. | • Linear regression (from scratch and with scikit-learn)<br>• Exploratory data analysis<br>• Feature engineering<br>• Regularization techniques<br>• Model validation |
-| [Module 3: Machine Learning for Classification](03-classification/) | Create a customer churn prediction system using logistic regression and learn about feature selection. | • Logistic regression<br>• Feature importance and selection<br>• Categorical variable encoding<br>• Model interpretation |
-| [Module 4: Evaluation Metrics for Classification](04-evaluation/) | Learn how to properly evaluate classification models and handle imbalanced datasets. | • Accuracy, precision, recall, F1-score<br>• ROC curves and AUC<br>• Cross-validation<br>• Confusion matrices<br>• Class imbalance handling |
-| [Module 5: Deploying Machine Learning Models](05-deployment/) | Turn your models into web services and deploy them with Docker and cloud platforms. | • Model serialization with Pickle<br>• FastAPI web services<br>• Docker containerization<br>• Cloud deployment |
-| [Module 6: Decision Trees & Ensemble Learning](06-trees/) | Learn tree-based models and ensemble methods for better predictions. | • Decision trees<br>• Random Forest<br>• Gradient boosting (XGBoost)<br>• Hyperparameter tuning<br>• Feature importance |
-| [Midterm Project](projects/) |  |  |
-| [Module 8: Neural Networks & Deep Learning](08-deep-learning/) | Introduction to neural networks using TensorFlow and Keras, including CNNs and transfer learning. | • Neural network fundamentals<br>• PyTorch<br>• TensorFlow & Keras<br>• Convolutional Neural Networks<br>• Transfer learning<br>• Model optimization |
-| [Module 9: Serverless Deep Learning](09-serverless/) | Deploy deep learning models using serverless technologies like AWS Lambda. | • Serverless concepts<br>• Deploying Scikit-Learn models with AWS Lambda<br>• Deploying TensorFlow and PyTorch models with AWS Lambda<br>• API Gateway |
-| [Module 10: Kubernetes & TensorFlow Serving](10-kubernetes/) | Learn to serve ML models at scale using Kubernetes and TensorFlow Serving. | • Kubernetes basics<br>• TensorFlow Serving<br>• Model deployment and scaling<br>• Load balancing |
-| [Capstone project 1](projects/) |  |  |
-| [Capstone project 2](projects/) |  |  |
+### [Module 1: Introduction to Machine Learning](01-intro/)
+
+Learn the fundamentals: what ML is, when to use it, and how to approach ML problems using the CRISP-DM framework.
+
+- ML vs rule-based systems
+- Supervised learning basics
+- CRISP-DM methodology
+- Model selection concepts
+- Environment setup
+
+### [Module 2: Machine Learning for Regression](02-regression/)
+
+Build a car price prediction model while learning linear regression, feature engineering, and regularization.
+
+- Linear regression (from scratch and with scikit-learn)
+- Exploratory data analysis
+- Feature engineering
+- Regularization techniques
+- Model validation
+
+### [Module 3: Machine Learning for Classification](03-classification/)
+
+Create a customer churn prediction system using logistic regression and learn about feature selection.
+
+- Logistic regression
+- Feature importance and selection
+- Categorical variable encoding
+- Model interpretation
+
+### [Module 4: Evaluation Metrics for Classification](04-evaluation/)
+
+Learn how to properly evaluate classification models and handle imbalanced datasets.
+
+- Accuracy, precision, recall, F1-score
+- ROC curves and AUC
+- Cross-validation
+- Confusion matrices
+- Class imbalance handling
+
+### [Module 5: Deploying Machine Learning Models](05-deployment/)
+
+Turn your models into web services and deploy them with Docker and cloud platforms.
+
+- Model serialization with Pickle
+- FastAPI web services
+- Docker containerization
+- Cloud deployment
+
+### [Module 6: Decision Trees & Ensemble Learning](06-trees/)
+
+Learn tree-based models and ensemble methods for better predictions.
+
+- Decision trees
+- Random Forest
+- Gradient boosting (XGBoost)
+- Hyperparameter tuning
+- Feature importance
+
+### [Midterm Project](projects/)
+
+Apply Modules 1-6 in an end-to-end project: pick a dataset, train a model, and deploy it as a web service.
+
+### [Module 8: Neural Networks & Deep Learning](08-deep-learning/)
+
+Introduction to neural networks using TensorFlow and Keras, including CNNs and transfer learning.
+
+- Neural network fundamentals
+- PyTorch
+- TensorFlow & Keras
+- Convolutional Neural Networks
+- Transfer learning
+- Model optimization
+
+### [Module 9: Serverless Deep Learning](09-serverless/)
+
+Deploy deep learning models using serverless technologies like AWS Lambda.
+
+- Serverless concepts
+- Deploying Scikit-Learn models with AWS Lambda
+- Deploying TensorFlow and PyTorch models with AWS Lambda
+- API Gateway
+
+### [Module 10: Kubernetes & TensorFlow Serving](10-kubernetes/)
+
+Learn to serve ML models at scale using Kubernetes and TensorFlow Serving.
+
+- Kubernetes basics
+- TensorFlow Serving
+- Model deployment and scaling
+- Load balancing
+
+### [Capstone Project 1](projects/)
+
+A larger end-to-end project at the end of the course, after Module 10.
+
+### [Capstone Project 2](projects/)
+
+An optional second capstone, which together with the midterm or first capstone counts toward your two required projects.
 
 ## Projects
 
@@ -186,6 +232,8 @@ To receive a certificate, you'll need to complete and submit two projects:
 1. Complete two projects: submit either a midterm project and a capstone project, OR two capstone projects
 2. Submit on time: meet the project submission deadlines to qualify for certification
 3. Peer review: evaluate and provide feedback on 3 fellow students' projects during the peer review process
+
+See the [certificate guide](https://datatalks.club/docs/courses/zoomcamp-logistics/certification/) for how the certificate is issued and how to add it to LinkedIn.
 
 ## Testimonials
 


### PR DESCRIPTION
Reorganizes the root README to follow the shared structure spec in [DataTalksClub/zoomcamp-template](https://github.com/DataTalksClub/zoomcamp-template), matching the MLOps and DE migrations.

## What changed
- Reordered the banner block: image → title → tagline → signup button → link row → status badges
- Dropped the hand-maintained Table of Contents (GitHub auto-generates an outline from the headings)
- Added a Quick Links table (including a Documentation row) and badges
- Renamed "How to Join" → "How to Take the Course"; folded Option 1 / Option 2 into "Live Cohort" / "Self-Paced" while keeping the mermaid decision diagram and the comparison table
- Standardized "Community & Getting Help" → "Community & Support" with "Getting Help on Slack" / "Learning in Public"
- Removed all bold formatting per the shared no-bold convention (including `<strong>` in the title and CTAs)
- Updated the stale "2025 cohort" CTA to 2026; community-navigation link → datatalks.club/docs/general

## Preserved
The full syllabus table, projects section with past-cohort examples, the certificate image and requirements, and all six testimonials.

## Note
Title kept as "A Free 4-Month Course" since ML genuinely runs September–December, unlike the 9–10 week camps. No Instructors section was added (the README never had one) to avoid inventing content.