### PR TITLE
project-tips: expand the data-leakage line into a concrete checklist

### DIFF
--- a/projects/project-tips.md
+++ b/projects/project-tips.md
@@ -41,7 +41,20 @@ If a Kaggle notebook already solves a similar task, it's likely doable in 2 week
 - Start with a **baseline** (Logistic/Linear model or shallow tree).  
 - Train at least **3 models**, tune key hyperparameters, and select the best.  
 - Use **cross-validation** and keep a summary table of scores.
-- Avoid data leakage — don't include target-derived features.
+- **Check for label leakage** — don't include target-derived features:
+  - For every feature, ask: *would I actually know this value at prediction time?*
+    Columns recorded after the outcome (actual delivery days, discharge date,
+    final status) encode the answer instead of predicting it.
+  - Quick test: train a model on **each feature alone**. If one feature by
+    itself gets near-perfect scores, it's almost certainly leaking the target.
+  - Treat a suspiciously high score as a symptom, not a success. A real
+    example from a popular capstone dataset: DataCo late-delivery prediction
+    scores ~97% with the shipping-time columns included — but the label is
+    *computed from* those columns, so the model just restates the definition.
+    With only the features knowable at order time, the same models get ~69%
+    ([audit with reproduction scripts](https://github.com/ipezygj/dataco-late-delivery-audit)).
+    The lower number is the real one — and it's the one worth putting in
+    your README, with a sentence explaining why.
 
 ## 5. From Notebook → Script
 


### PR DESCRIPTION
## What

`projects/project-tips.md` already tells students to "avoid data leakage — don't include target-derived features", but gives no way to actually check for it. This expands that one line into a short, checkable list:

- the *would-I-know-this-at-prediction-time* question,
- the single-feature probe (train on each feature alone; near-perfect from one feature = leak),
- "a suspiciously high score is a symptom, not a success",
- a worked example from a dataset capstone projects genuinely use: **DataCo late-delivery prediction** scores ~97% when the shipping-time columns are included — but the label is computed from those columns, so the model restates the definition. With only order-time features the same models get ~69%. Students hit this exact trap (e.g. several past cohort capstones use this dataset), and public works keep republishing the leaked figure — 28 of 65 in a census of papers and notebooks. The linked audit has reproduction scripts, so it doubles as an example of what a good project README can look like when a number needs defending.

Framing follows the course's tone: the lower, honest number is the one worth putting in the README — which is also what the rubric's "clear problem description" asks for.

(Also mentioned in a mail to Alexey on Aug 8 — this is the PR that mail promised.)
