### PR TITLE
Add SITE.md for the website course description

### DIFF
--- a/SITE.md
+++ b/SITE.md
@@ -1,0 +1,5 @@
+# Machine Learning Zoomcamp
+
+Machine Learning Zoomcamp is a free, hands-on course on machine learning engineering. Across its modules you work through regression, classification, model evaluation, tree-based models, and deep learning, then deploy what you build with FastAPI, Docker, AWS Lambda, and Kubernetes. A midterm project and a capstone project bookend the second half of the course.
+
+The course follows a project-first approach: theory is introduced as it is needed to solve real problems, with the focus on the practical engineering skills used in industry. All materials stay available for self-paced study between cohorts.


### PR DESCRIPTION
Adds `SITE.md`, a short course description written for the DataTalks.Club website.

**Why:** the website takes this course's description from the repository. Today it reads `README.md`, which is written for a GitHub audience, so the website ends up rendering badges, centered HTML and contributor lists. `SITE.md` gives the website a file whose only job is to be that copy.

**Notes**

- `README.md` is unchanged. Nothing else in the repository changes.
- There is no `course.yaml` on `main` in this repository, so this PR has no `description_path` to repoint. Once a `course.yaml` lands here, its `description_path` should be set to `SITE.md`.
- The copy is condensed from the existing DataTalks.Club course page for this course in `DataTalksClub/docs` (`courses/ml-zoomcamp/`). It is a shortened version of authored copy rather than new marketing text, but it is worth an owner read before merging.
